### PR TITLE
feat: release pipeline, tag import / export improvements

### DIFF
--- a/.github/RELEASE_QUICKSTART.md
+++ b/.github/RELEASE_QUICKSTART.md
@@ -2,118 +2,99 @@
 
 ## First-Time Setup
 
-### 1. Generate a Keystore
+### 1. Add Code Signing Secrets
 
 ```bash
+# Generate a keystore
 keytool -genkeypair \
   -alias ignition-git-module \
-  -keyalg RSA \
-  -keysize 2048 \
-  -validity 3650 \
+  -keyalg RSA -keysize 2048 -validity 3650 \
   -keystore keystore.jks
-```
 
-Follow the prompts to set:
-- Keystore password (keep secure!)
-- Key password (keep secure!)
-- Your organization details
-
-### 2. Set GitHub Secrets
-
-```bash
-# Encode keystore to base64
+# Encode to base64
 base64 -i keystore.jks -o keystore.txt
 ```
 
-Add these secrets in GitHub (Settings → Secrets and variables → Actions):
+Add these secrets in GitHub (Settings > Secrets and variables > Actions):
 - `KEYSTORE_BASE64` = contents of keystore.txt
-- `KEYSTORE_ALIAS` = `ignition-git-module` (or your chosen alias)
+- `KEYSTORE_ALIAS` = `ignition-git-module`
 - `KEYSTORE_STOREPASS` = your keystore password
 - `KEYSTORE_KEYPASS` = your key password
 
-### 3. Delete the keystore files locally
-
 ```bash
+# Clean up local files
 rm keystore.jks keystore.txt
 ```
 
+### 2. Add Release PAT
+
+Create a fine-grained Personal Access Token with `contents: write` permission, then add it as the `RELEASE_PAT` secret. This is needed so the tag push triggers the release build.
+
 ## Creating a Release
 
-### Quick Method (Recommended)
+### Stable Release
+
+1. Go to **Actions > Create Release > Run workflow**
+2. Pick `bump_type`: `patch`, `minor`, or `major`
+3. Click **Run workflow**
+
+### Pre-release
+
+1. Go to **Actions > Create Release > Run workflow**
+2. Set `bump_type` to `prerelease`
+3. Pick `prerelease_type`: `alpha`, `beta`, or `rc`
+4. Click **Run workflow**
+
+### Promote Pre-release to Stable
+
+1. Run **Create Release** with `bump_type: patch`
+2. The pre-release suffix is stripped (e.g., `2.1.0-rc.1` becomes `2.1.0`)
+
+### Dry Run
+
+Check `dry_run` to preview the version change without pushing anything.
+
+## Version Examples
+
+| Current | Bump | Pre-release | Result |
+|---------|------|-------------|--------|
+| `2.0.0` | patch | - | `2.0.1` |
+| `2.0.0` | minor | - | `2.1.0` |
+| `2.0.0` | prerelease | beta | `2.1.0-beta.1` |
+| `2.1.0-beta.1` | prerelease | beta | `2.1.0-beta.2` |
+| `2.1.0-beta.2` | prerelease | rc | `2.1.0-rc.1` |
+| `2.1.0-rc.1` | patch | - | `2.1.0` |
+
+## What Happens
+
+1. **Create Release** bumps versions in pom.xml + package.json, commits, tags, pushes
+2. **Release** (triggered by the tag) builds the module, signs it, creates a GitHub Release
+3. Pre-releases get the **Pre-release** badge on GitHub
+
+## Local Builds
 
 ```bash
-# 1. Update version in pom.xml (e.g., change to 2.1.0)
-# 2. Commit and push
-git add pom.xml
-git commit -m "chore: bump version to 2.1.0"
-git push origin main
+# Unsigned (fast)
+mvn clean package -DskipTests
 
-# 3. Tag and push
-git tag v2.1.0
-git push origin v2.1.0
-```
-
-GitHub Actions will automatically:
-- ✅ Build the module
-- ✅ Sign the module
-- ✅ Create a GitHub release
-- ✅ Upload signed and unsigned .modl files
-
-### Manual Trigger
-
-1. Go to GitHub → Actions → "Build and Release"
-2. Click "Run workflow"
-3. Select branch and release type
-4. Click "Run workflow"
-
-## Local Development Builds
-
-### Unsigned Build (Fast)
-```bash
-mvn clean package
-```
-
-### Signed Build (Local Testing)
-```bash
+# Signed
 mvn clean package -Psign \
   -Dkeystore.path=/path/to/keystore.jks \
   -Dkeystore.alias=ignition-git-module \
-  -Dkeystore.storepass=YOUR_PASSWORD \
-  -Dkeystore.keypass=YOUR_PASSWORD
-```
+  -Dkeystore.storepass=PASSWORD \
+  -Dkeystore.keypass=PASSWORD
 
-### Verify Signature
-```bash
+# Verify
 jarsigner -verify -verbose git-build/target/*.modl
 ```
 
 ## Troubleshooting
 
-### "KEYSTORE_BASE64 secret not found"
-→ Set up GitHub secrets (see step 2 above)
-
-### "jar verify failed"
-→ Check keystore passwords in GitHub secrets
-
-### "Module not found in release"
-→ Check GitHub Actions logs for build errors
-
-## Where to Find Files
-
-- Built module: `git-build/target/*.modl`
-- GitHub releases: https://github.com/WHK01/ignition-git-module/releases
-- Workflow logs: https://github.com/WHK01/ignition-git-module/actions
-
-## Version Numbering
-
-Follow semantic versioning:
-- **Major** (X.0.0): Breaking changes
-- **Minor** (0.X.0): New features
-- **Patch** (0.0.X): Bug fixes
-
-Examples:
-- `2.0.0` → `2.1.0` (added new feature)
-- `2.1.0` → `2.1.1` (bug fix)
-- `2.1.1` → `3.0.0` (breaking change)
+| Problem | Fix |
+|---------|-----|
+| Release workflow not triggered | Check `RELEASE_PAT` secret is set and not expired |
+| POM version mismatch | Run Create Release workflow instead of manual tagging |
+| Module not signed | Check all 4 keystore secrets are configured |
+| npm build fails | Ensure Node.js 18+ is available |
 
 For complete documentation, see [../RELEASE.md](../RELEASE.md)

--- a/.github/RELEASE_QUICKSTART.md
+++ b/.github/RELEASE_QUICKSTART.md
@@ -41,7 +41,7 @@ Create a fine-grained Personal Access Token with `contents: write` permission, t
 ### Pre-release
 
 1. Go to **Actions > Create Release > Run workflow**
-2. Set `bump_type` to `prerelease`
+2. Set `bump_type` to `prerelease` (no hyphen in the input value)
 3. Pick `prerelease_type`: `alpha`, `beta`, or `rc`
 4. Click **Run workflow**
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+        - feat
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Maintenance
+      labels:
+        - chore
+        - dependencies
+        - documentation
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -167,7 +167,7 @@ jobs:
           echo "  2. Update web/packages/gateway/package.json to ${{ steps.new_version.outputs.version }}"
           echo "  3. Commit: 'chore(release): ${{ steps.new_version.outputs.version }}'"
           echo "  4. Tag: v${{ steps.new_version.outputs.version }}"
-          echo "  5. Push commit and tag to main"
+          echo "  5. Push commit and tag to default branch"
           echo "  6. release.yml will trigger to build, sign, and publish"
 
       - name: Commit, tag, and push
@@ -179,6 +179,6 @@ jobs:
           git add -A
           git commit -m "chore(release): ${{ steps.new_version.outputs.version }}"
           git tag "v${{ steps.new_version.outputs.version }}"
-          git push origin main --follow-tags
+          git push origin ${{ github.event.repository.default_branch }} --follow-tags
 
           echo "Pushed v${{ steps.new_version.outputs.version }} - release.yml will now build and publish"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,184 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+      prerelease_type:
+        description: 'Pre-release type (only used when bump_type is prerelease)'
+        required: false
+        type: choice
+        default: 'beta'
+        options:
+          - alpha
+          - beta
+          - rc
+      dry_run:
+        description: 'Dry run (show what would happen without pushing)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  bump-version:
+    name: Bump Version & Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Read current version
+        id: current
+        run: |
+          CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $CURRENT_VERSION"
+
+      - name: Calculate new version
+        id: new_version
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          PRERELEASE_TYPE: ${{ inputs.prerelease_type }}
+          CURRENT_VERSION: ${{ steps.current.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Parse current version
+          # Handles: 2.0.0, 2.1.0-beta.1, 2.1.0-rc.2
+          if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z]+)\.([0-9]+))?$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            PRE_TYPE="${BASH_REMATCH[5]}"
+            PRE_NUM="${BASH_REMATCH[6]}"
+          else
+            echo "Error: Cannot parse version '$CURRENT_VERSION'"
+            exit 1
+          fi
+
+          IS_PRERELEASE=false
+          if [ -n "$PRE_TYPE" ]; then
+            IS_PRERELEASE=true
+          fi
+
+          echo "Parsed: MAJOR=$MAJOR MINOR=$MINOR PATCH=$PATCH PRE_TYPE=$PRE_TYPE PRE_NUM=$PRE_NUM"
+          echo "Current is pre-release: $IS_PRERELEASE"
+
+          case "$BUMP_TYPE" in
+            major)
+              NEW_VERSION="$((MAJOR + 1)).0.0"
+              ;;
+            minor)
+              if [ "$IS_PRERELEASE" = true ]; then
+                # Promoting from pre-release: if pre-release was on this minor, just use it
+                NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+              else
+                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+              fi
+              ;;
+            patch)
+              if [ "$IS_PRERELEASE" = true ]; then
+                # Promoting pre-release to stable: 2.1.0-beta.1 -> 2.1.0
+                NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+              else
+                NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              fi
+              ;;
+            prerelease)
+              if [ "$IS_PRERELEASE" = true ]; then
+                if [ "$PRE_TYPE" = "$PRERELEASE_TYPE" ]; then
+                  # Same pre-release type: increment number
+                  # 2.1.0-beta.1 -> 2.1.0-beta.2
+                  NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-${PRERELEASE_TYPE}.$((PRE_NUM + 1))"
+                else
+                  # Different pre-release type: start at 1
+                  # 2.1.0-beta.2 -> 2.1.0-rc.1
+                  NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-${PRERELEASE_TYPE}.1"
+                fi
+              else
+                # From stable: bump minor and start pre-release
+                # 2.0.0 -> 2.1.0-beta.1
+                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0-${PRERELEASE_TYPE}.1"
+              fi
+              ;;
+            *)
+              echo "Error: Unknown bump type '$BUMP_TYPE'"
+              exit 1
+              ;;
+          esac
+
+          echo "New version: $NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update Maven versions
+        if: ${{ !inputs.dry_run }}
+        run: |
+          mvn versions:set -DnewVersion=${{ steps.new_version.outputs.version }} -DgenerateBackupPoms=false
+          echo "Updated pom.xml files to ${{ steps.new_version.outputs.version }}"
+
+      - name: Update npm package version
+        if: ${{ !inputs.dry_run }}
+        working-directory: web/packages/gateway
+        run: |
+          npm version "${{ steps.new_version.outputs.version }}" --no-git-tag-version --allow-same-version
+          echo "Updated package.json to ${{ steps.new_version.outputs.version }}"
+
+      - name: Show changes (dry run)
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "============================================"
+          echo "DRY RUN - No changes will be made"
+          echo "============================================"
+          echo ""
+          echo "Current version: ${{ steps.current.outputs.version }}"
+          echo "New version:     ${{ steps.new_version.outputs.version }}"
+          echo "Bump type:       ${{ inputs.bump_type }}"
+          echo "Pre-release:     ${{ inputs.prerelease_type }}"
+          echo "Tag:             v${{ steps.new_version.outputs.version }}"
+          echo ""
+          echo "Actions that would be taken:"
+          echo "  1. Update all pom.xml files to ${{ steps.new_version.outputs.version }}"
+          echo "  2. Update web/packages/gateway/package.json to ${{ steps.new_version.outputs.version }}"
+          echo "  3. Commit: 'chore(release): ${{ steps.new_version.outputs.version }}'"
+          echo "  4. Tag: v${{ steps.new_version.outputs.version }}"
+          echo "  5. Push commit and tag to main"
+          echo "  6. release.yml will trigger to build, sign, and publish"
+
+      - name: Commit, tag, and push
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          git commit -m "chore(release): ${{ steps.new_version.outputs.version }}"
+          git tag "v${{ steps.new_version.outputs.version }}"
+          git push origin main --follow-tags
+
+          echo "Pushed v${{ steps.new_version.outputs.version }} - release.yml will now build and publish"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -70,8 +70,8 @@ jobs:
           set -euo pipefail
 
           # Parse current version
-          # Handles: 2.0.0, 2.1.0-beta.1, 2.1.0-rc.2
-          if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z]+)\.([0-9]+))?$ ]]; then
+          # Handles: 2.0.0, 2.1.0-beta1, 2.1.0-rc2
+          if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z]+)([0-9]+))?$ ]]; then
             MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="${BASH_REMATCH[3]}"
@@ -104,7 +104,7 @@ jobs:
               ;;
             patch)
               if [ "$IS_PRERELEASE" = true ]; then
-                # Promoting pre-release to stable: 2.1.0-beta.1 -> 2.1.0
+                # Promoting pre-release to stable: 2.1.0-beta1 -> 2.1.0
                 NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
               else
                 NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
@@ -114,17 +114,17 @@ jobs:
               if [ "$IS_PRERELEASE" = true ]; then
                 if [ "$PRE_TYPE" = "$PRERELEASE_TYPE" ]; then
                   # Same pre-release type: increment number
-                  # 2.1.0-beta.1 -> 2.1.0-beta.2
-                  NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-${PRERELEASE_TYPE}.$((PRE_NUM + 1))"
+                  # 2.1.0-beta1 -> 2.1.0-beta2
+                  NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-${PRERELEASE_TYPE}$((PRE_NUM + 1))"
                 else
                   # Different pre-release type: start at 1
-                  # 2.1.0-beta.2 -> 2.1.0-rc.1
-                  NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-${PRERELEASE_TYPE}.1"
+                  # 2.1.0-beta2 -> 2.1.0-rc1
+                  NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-${PRERELEASE_TYPE}1"
                 fi
               else
                 # From stable: bump minor and start pre-release
-                # 2.0.0 -> 2.1.0-beta.1
-                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0-${PRERELEASE_TYPE}.1"
+                # 2.0.0 -> 2.1.0-beta1
+                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0-${PRERELEASE_TYPE}1"
               fi
               ;;
             *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      HAS_KEYSTORE: ${{ secrets.KEYSTORE_BASE64 != '' }}
 
     steps:
       - name: Checkout code
@@ -37,10 +39,7 @@ jobs:
             echo "Detected stable release: $TAG_VERSION"
           fi
 
-          # Extract base version (strip pre-release suffix) for Ignition module version
-          BASE_VERSION=$(echo "$TAG_VERSION" | sed 's/-.*//')
-          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
-          echo "Base version for Ignition: $BASE_VERSION"
+          echo "Tag version for module: $TAG_VERSION"
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
@@ -65,20 +64,9 @@ jobs:
           fi
           echo "POM version matches tag: $POM_VERSION"
 
-      - name: Compute Ignition module version
-        id: module_version
-        run: |
-          # Ignition requires 4-part MAJOR.MINOR.PATCH.BUILD format
-          # Strip pre-release suffix and append build timestamp
-          BASE="${{ steps.version.outputs.base_version }}"
-          TIMESTAMP=$(date -u +"%Y%m%d%H")
-          MODULE_VERSION="${BASE}.${TIMESTAMP}"
-          echo "module_version=$MODULE_VERSION" >> $GITHUB_OUTPUT
-          echo "Ignition module version: $MODULE_VERSION"
-
       - name: Build module
         run: |
-          mvn clean package -DskipTests -Dmodule.version=${{ steps.module_version.outputs.module_version }}
+          mvn clean package -DskipTests -Dmodule.version=${{ steps.version.outputs.tag_version }}
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
 
@@ -96,12 +84,12 @@ jobs:
           fi
 
       - name: Decode keystore
-        if: secrets.KEYSTORE_BASE64 != ''
+        if: env.HAS_KEYSTORE == 'true'
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ${{ runner.temp }}/keystore.jks
 
       - name: Sign module
-        if: secrets.KEYSTORE_BASE64 != ''
+        if: env.HAS_KEYSTORE == 'true'
         run: |
           cd git-build/target
           MODL_FILE=$(ls *.modl | grep -v "unsigned" | head -1)
@@ -121,7 +109,7 @@ jobs:
           JAVA_HOME: ${{ env.JAVA_HOME }}
 
       - name: Verify signed module
-        if: secrets.KEYSTORE_BASE64 != ''
+        if: env.HAS_KEYSTORE == 'true'
         run: |
           cd git-build/target
           MODL_FILE=$(ls *.modl | grep -v "unsigned" | head -1)
@@ -131,7 +119,7 @@ jobs:
           fi
 
       - name: Rename signed module
-        if: secrets.KEYSTORE_BASE64 != ''
+        if: env.HAS_KEYSTORE == 'true'
         run: |
           cd git-build/target
           MODL_FILE=$(ls *.modl | grep -v "unsigned" | head -1)
@@ -160,6 +148,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clean up keystore
-        if: always() && secrets.KEYSTORE_BASE64 != ''
+        if: always() && env.HAS_KEYSTORE == 'true'
         run: |
           rm -f ${{ runner.temp }}/keystore.jks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,18 @@
-name: Build and Release
+name: Release
 
 on:
   push:
     tags:
-      - 'v*.*.*'
-  workflow_dispatch:
-    inputs:
-      release_type:
-        description: 'Release type'
-        required: true
-        default: 'snapshot'
-        type: choice
-        options:
-          - snapshot
-          - release
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 env:
   JAVA_VERSION: '17'
   NODE_VERSION: '18'
 
 jobs:
-  build:
-    name: Build Ignition Git Module
+  release:
+    name: Build, Sign & Publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,6 +21,26 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Determine version info
+        id: version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "tag_version=$TAG_VERSION" >> $GITHUB_OUTPUT
+
+          # Detect pre-release: contains a hyphen after the version triplet
+          if [[ "$TAG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "Detected pre-release: $TAG_VERSION"
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "Detected stable release: $TAG_VERSION"
+          fi
+
+          # Extract base version (strip pre-release suffix) for Ignition module version
+          BASE_VERSION=$(echo "$TAG_VERSION" | sed 's/-.*//')
+          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
+          echo "Base version for Ignition: $BASE_VERSION"
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
@@ -43,23 +54,31 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Determine version
-        id: version
+      - name: Verify POM version matches tag
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "is_release=true" >> $GITHUB_OUTPUT
-          else
-            # Use POM version for snapshots
-            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-            echo "version=$VERSION-SNAPSHOT" >> $GITHUB_OUTPUT
-            echo "is_release=false" >> $GITHUB_OUTPUT
+          POM_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          TAG_VERSION="${{ steps.version.outputs.tag_version }}"
+          if [ "$POM_VERSION" != "$TAG_VERSION" ]; then
+            echo "Error: POM version ($POM_VERSION) does not match tag version ($TAG_VERSION)"
+            echo "Did you forget to run the create-release workflow?"
+            exit 1
           fi
+          echo "POM version matches tag: $POM_VERSION"
 
-      - name: Build unsigned module
+      - name: Compute Ignition module version
+        id: module_version
         run: |
-          mvn clean package -DskipTests
+          # Ignition requires 4-part MAJOR.MINOR.PATCH.BUILD format
+          # Strip pre-release suffix and append build timestamp
+          BASE="${{ steps.version.outputs.base_version }}"
+          TIMESTAMP=$(date -u +"%Y%m%d%H")
+          MODULE_VERSION="${BASE}.${TIMESTAMP}"
+          echo "module_version=$MODULE_VERSION" >> $GITHUB_OUTPUT
+          echo "Ignition module version: $MODULE_VERSION"
+
+      - name: Build module
+        run: |
+          mvn clean package -DskipTests -Dmodule.version=${{ steps.module_version.outputs.module_version }}
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
 
@@ -68,21 +87,21 @@ jobs:
           cd git-build/target
           MODL_FILE=$(ls *.modl | head -1)
           if [ -n "$MODL_FILE" ]; then
-            cp "$MODL_FILE" "Git-${{ steps.version.outputs.version }}-unsigned.modl"
-            echo "Preserved unsigned module: Git-${{ steps.version.outputs.version }}-unsigned.modl"
-            ls -lh "Git-${{ steps.version.outputs.version }}-unsigned.modl"
+            cp "$MODL_FILE" "Git-${{ steps.version.outputs.tag_version }}-unsigned.modl"
+            echo "Preserved unsigned module: Git-${{ steps.version.outputs.tag_version }}-unsigned.modl"
+            ls -lh "Git-${{ steps.version.outputs.tag_version }}-unsigned.modl"
           else
             echo "Error: No .modl file found"
             exit 1
           fi
 
       - name: Decode keystore
-        if: steps.version.outputs.is_release == 'true' && secrets.KEYSTORE_BASE64 != ''
+        if: secrets.KEYSTORE_BASE64 != ''
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ${{ runner.temp }}/keystore.jks
 
       - name: Sign module
-        if: steps.version.outputs.is_release == 'true' && secrets.KEYSTORE_BASE64 != ''
+        if: secrets.KEYSTORE_BASE64 != ''
         run: |
           cd git-build/target
           MODL_FILE=$(ls *.modl | grep -v "unsigned" | head -1)
@@ -102,7 +121,7 @@ jobs:
           JAVA_HOME: ${{ env.JAVA_HOME }}
 
       - name: Verify signed module
-        if: steps.version.outputs.is_release == 'true' && secrets.KEYSTORE_BASE64 != ''
+        if: secrets.KEYSTORE_BASE64 != ''
         run: |
           cd git-build/target
           MODL_FILE=$(ls *.modl | grep -v "unsigned" | head -1)
@@ -112,78 +131,31 @@ jobs:
           fi
 
       - name: Rename signed module
-        if: steps.version.outputs.is_release == 'true' && secrets.KEYSTORE_BASE64 != ''
+        if: secrets.KEYSTORE_BASE64 != ''
         run: |
           cd git-build/target
           MODL_FILE=$(ls *.modl | grep -v "unsigned" | head -1)
           if [ -n "$MODL_FILE" ]; then
-            mv "$MODL_FILE" "Git-${{ steps.version.outputs.version }}-signed.modl"
-            echo "Renamed signed module: Git-${{ steps.version.outputs.version }}-signed.modl"
+            mv "$MODL_FILE" "Git-${{ steps.version.outputs.tag_version }}-signed.modl"
+            echo "Renamed signed module: Git-${{ steps.version.outputs.tag_version }}-signed.modl"
             ls -lh Git-*.modl
           fi
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ignition-git-module-${{ steps.version.outputs.version }}
-          path: git-build/target/Git-${{ steps.version.outputs.version }}-*.modl
-          retention-days: 30
-
-      - name: Prepare release notes
-        if: steps.version.outputs.is_release == 'true'
-        id: release_notes
-        run: |
-          if [ -f "git-build/target/Git-${{ steps.version.outputs.version }}-signed.modl" ]; then
-            cat << 'EOF' > release_notes.md
-          ## Ignition Git Module v${{ steps.version.outputs.version }}
-
-          ### Installation
-          1. Download the `.modl` file below
-          2. Install via Ignition Gateway Config > System > Modules
-          3. Restart the gateway if prompted
-
-          ### Files
-          - `Git-${{ steps.version.outputs.version }}-signed.modl` - Signed module (recommended for production)
-          - `Git-${{ steps.version.outputs.version }}-unsigned.modl` - Unsigned module (for testing)
-
-          ### Compatibility
-          - Requires Ignition 8.3.1 or later
-          - Requires Java 17+
-
-          For version 8.1.x support, see [v1.0.3-ignition-8.1](https://github.com/WHK01/ignition-git-module/releases/tag/v1.0.3-ignition-8.1)
-          EOF
-          else
-            cat << 'EOF' > release_notes.md
-          ## Ignition Git Module v${{ steps.version.outputs.version }}
-
-          ### Installation
-          1. Download the `.modl` file below
-          2. Install via Ignition Gateway Config > System > Modules
-          3. Restart the gateway if prompted
-
-          ### Files
-          - `Git-${{ steps.version.outputs.version }}-unsigned.modl` - Unsigned module
-
-          **Note:** This release does not include a signed version. Configure signing secrets to enable module signing.
-
-          ### Compatibility
-          - Requires Ignition 8.3.1 or later
-          - Requires Java 17+
-
-          For version 8.1.x support, see [v1.0.3-ignition-8.1](https://github.com/WHK01/ignition-git-module/releases/tag/v1.0.3-ignition-8.1)
-          EOF
-          fi
+          name: ignition-git-module-${{ steps.version.outputs.tag_version }}
+          path: git-build/target/Git-${{ steps.version.outputs.tag_version }}-*.modl
+          retention-days: 90
 
       - name: Create GitHub Release
-        if: steps.version.outputs.is_release == 'true'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.version.outputs.is_prerelease }}
           generate_release_notes: true
           files: |
-            git-build/target/Git-${{ steps.version.outputs.version }}-*.modl
-          body_path: release_notes.md
+            git-build/target/Git-${{ steps.version.outputs.tag_version }}-*.modl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,16 +74,16 @@ The workflow will:
 3. Set `prerelease_type` to `alpha`, `beta`, or `rc`
 4. Click **Run workflow**
 
-Pre-release versions follow the pattern `X.Y.Z-type.N` (e.g., `2.1.0-beta.1`).
+Pre-release versions follow the pattern `X.Y.Z-typeN` (e.g., `2.1.0-beta1`).
 
 The GitHub Release will be marked with the **Pre-release** badge.
 
 ### Promoting a Pre-release to Stable
 
-To promote a pre-release (e.g., `2.1.0-rc.2`) to a stable release:
+To promote a pre-release (e.g., `2.1.0-rc2`) to a stable release:
 
 1. Run **Create Release** with `bump_type: patch`
-2. This strips the pre-release suffix: `2.1.0-rc.2` becomes `2.1.0`
+2. This strips the pre-release suffix: `2.1.0-rc2` becomes `2.1.0`
 
 ### Dry Run
 
@@ -96,10 +96,10 @@ Set `dry_run: true` to preview what the workflow would do without making any cha
 | `2.0.0` | patch | - | `2.0.1` |
 | `2.0.0` | minor | - | `2.1.0` |
 | `2.0.0` | major | - | `3.0.0` |
-| `2.0.0` | prerelease | beta | `2.1.0-beta.1` |
-| `2.1.0-beta.1` | prerelease | beta | `2.1.0-beta.2` |
-| `2.1.0-beta.2` | prerelease | rc | `2.1.0-rc.1` |
-| `2.1.0-rc.1` | patch | - | `2.1.0` |
+| `2.0.0` | prerelease | beta | `2.1.0-beta1` |
+| `2.1.0-beta1` | prerelease | beta | `2.1.0-beta2` |
+| `2.1.0-beta2` | prerelease | rc | `2.1.0-rc1` |
+| `2.1.0-rc1` | patch | - | `2.1.0` |
 
 ## Ignition Module Versioning
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,29 +4,20 @@ This document describes the automated release pipeline for the Ignition Git Modu
 
 ## Overview
 
-The project includes two GitHub Actions workflows:
+The project uses two release-related GitHub Actions workflows:
 
-1. **Continuous Integration (CI)** - Runs on PRs and pushes to main
-2. **Build and Release** - Creates releases with signed modules
+1. **Create Release** (`create-release.yml`) - Bumps versions, commits, tags, and pushes
+2. **Release** (`release.yml`) - Builds, signs, and publishes when a tag is pushed
 
-## Continuous Integration
+Releases are triggered via the **Create Release** workflow dispatch in GitHub Actions. It handles version calculation, updates all version files, commits, tags, and pushes. The tag push then triggers the **Release** workflow which builds the module, signs it, and creates the GitHub Release.
 
-The CI workflow (`ci.yml`) automatically runs on:
-- Pull requests to main
-- Pushes to main branch
+## Prerequisites
 
-It performs:
-- Maven build verification
-- Module compilation
-- Artifact creation (7-day retention)
+### Code Signing Keystore
 
-## Release Process
+To produce signed releases, configure these GitHub Secrets:
 
-### Prerequisites
-
-To create signed releases, you need to set up GitHub Secrets with your code signing keystore:
-
-1. **Generate a Keystore** (if you don't have one):
+1. **Generate a keystore** (if you don't have one):
    ```bash
    keytool -genkeypair \
      -alias ignition-git-module \
@@ -34,82 +25,108 @@ To create signed releases, you need to set up GitHub Secrets with your code sign
      -keysize 2048 \
      -validity 3650 \
      -keystore keystore.jks \
-     -dname "CN=Your Name, OU=Your Organization, O=Your Company, L=City, ST=State, C=US"
+     -dname "CN=Your Name, OU=Your Org, O=Your Company, L=City, ST=State, C=US"
    ```
 
-2. **Encode the Keystore to Base64**:
+2. **Encode to base64**:
    ```bash
    base64 -i keystore.jks -o keystore.txt
    ```
 
-3. **Set up GitHub Secrets**:
+3. **Add GitHub Secrets** (Settings > Secrets and variables > Actions):
+   - `KEYSTORE_BASE64` - Contents of keystore.txt
+   - `KEYSTORE_ALIAS` - Alias used when creating the keystore
+   - `KEYSTORE_STOREPASS` - Keystore password
+   - `KEYSTORE_KEYPASS` - Key password
 
-   Navigate to your repository on GitHub:
-   Settings → Secrets and variables → Actions → New repository secret
-
-   Add the following secrets:
-   - `KEYSTORE_BASE64` - Contents of keystore.txt (base64 encoded keystore)
-   - `KEYSTORE_ALIAS` - The alias used when creating the keystore (e.g., "ignition-git-module")
-   - `KEYSTORE_STOREPASS` - The keystore password
-   - `KEYSTORE_KEYPASS` - The key password
-
-### Creating a Release
-
-#### Method 1: Tag-based Release (Recommended)
-
-1. **Update the version in pom.xml**:
-   ```xml
-   <version>2.1.0</version>
-   ```
-
-2. **Commit and push your changes**:
+4. **Delete local keystore files**:
    ```bash
-   git add pom.xml
-   git commit -m "chore: bump version to 2.1.0"
-   git push origin main
+   rm keystore.jks keystore.txt
    ```
 
-3. **Create and push a version tag**:
-   ```bash
-   git tag v2.1.0
-   git push origin v2.1.0
-   ```
+### Release PAT
 
-4. **The workflow will automatically**:
-   - Build the unsigned module
-   - Build and sign the module (if secrets are configured)
-   - Create a GitHub release
-   - Upload both signed and unsigned .modl files
-   - Generate release notes
+The **Create Release** workflow needs a Personal Access Token so that its tag push triggers the **Release** workflow (pushes using `GITHUB_TOKEN` don't trigger other workflows).
 
-#### Method 2: Manual Workflow Dispatch
+1. Create a fine-grained PAT with `contents: write` permission for this repository
+2. Add it as the `RELEASE_PAT` secret in GitHub
 
-1. Go to Actions → Build and Release → Run workflow
-2. Select the branch
-3. Choose release type (snapshot/release)
-4. Click "Run workflow"
+## Creating a Release
 
-This creates a snapshot build without creating a GitHub release.
+### Standard Release (patch / minor / major)
+
+1. Go to **Actions > Create Release > Run workflow**
+2. Set `bump_type` to `patch`, `minor`, or `major`
+3. Leave `dry_run` unchecked
+4. Click **Run workflow**
+
+The workflow will:
+- Read the current version from pom.xml
+- Calculate the new version
+- Update all pom.xml files and package.json
+- Commit, tag (`vX.Y.Z`), and push
+- The tag push triggers the Release workflow which builds, signs, and publishes
+
+### Pre-release
+
+1. Go to **Actions > Create Release > Run workflow**
+2. Set `bump_type` to `prerelease`
+3. Set `prerelease_type` to `alpha`, `beta`, or `rc`
+4. Click **Run workflow**
+
+Pre-release versions follow the pattern `X.Y.Z-type.N` (e.g., `2.1.0-beta.1`).
+
+The GitHub Release will be marked with the **Pre-release** badge.
+
+### Promoting a Pre-release to Stable
+
+To promote a pre-release (e.g., `2.1.0-rc.2`) to a stable release:
+
+1. Run **Create Release** with `bump_type: patch`
+2. This strips the pre-release suffix: `2.1.0-rc.2` becomes `2.1.0`
+
+### Dry Run
+
+Set `dry_run: true` to preview what the workflow would do without making any changes.
+
+### Version Calculation Examples
+
+| Current | Bump Type | Pre-release Type | Result |
+|---------|-----------|------------------|--------|
+| `2.0.0` | patch | - | `2.0.1` |
+| `2.0.0` | minor | - | `2.1.0` |
+| `2.0.0` | major | - | `3.0.0` |
+| `2.0.0` | prerelease | beta | `2.1.0-beta.1` |
+| `2.1.0-beta.1` | prerelease | beta | `2.1.0-beta.2` |
+| `2.1.0-beta.2` | prerelease | rc | `2.1.0-rc.1` |
+| `2.1.0-rc.1` | patch | - | `2.1.0` |
+
+## Ignition Module Versioning
+
+Ignition requires a 4-part `MAJOR.MINOR.PATCH.BUILD` module version and cannot parse SemVer pre-release suffixes. The Release workflow handles this by:
+
+1. Stripping the pre-release suffix from the tag version
+2. Appending a UTC build timestamp
+3. Passing it to Maven via `-Dmodule.version=X.Y.Z.YYYYMMDDHH`
+
+Example: Tag `v2.1.0-beta.1` produces Ignition module version `2.1.0.2026020614`.
 
 ## Build Artifacts
 
-After a successful release, the following artifacts are created:
+Each release produces:
+- `Git-{version}-signed.modl` - Signed module (when keystore secrets are configured)
+- `Git-{version}-unsigned.modl` - Unsigned module
 
-- `Git-{version}-signed.modl` - Signed module (recommended for production)
-- `Git-{version}-unsigned.modl` - Unsigned module (for testing)
+Artifacts are retained for 90 days and attached to the GitHub Release.
 
 ## Local Development
 
-### Building Unsigned Module
-
+### Unsigned build
 ```bash
-mvn clean package
+mvn clean package -DskipTests
 ```
 
-The .modl file will be in `git-build/target/`
-
-### Building Signed Module
-
+### Signed build
 ```bash
 mvn clean package -Psign \
   -Dkeystore.path=/path/to/keystore.jks \
@@ -118,88 +135,28 @@ mvn clean package -Psign \
   -Dkeystore.keypass=your-key-password
 ```
 
-### Verifying Signature
-
+### Verify signature
 ```bash
 jarsigner -verify -verbose -certs git-build/target/*.modl
 ```
 
-Expected output should include:
-```
-jar verified.
-```
-
-## Versioning Strategy
-
-This project follows [Semantic Versioning](https://semver.org/):
-
-- **MAJOR** version (X.0.0): Incompatible API changes
-- **MINOR** version (0.X.0): New functionality, backwards compatible
-- **PATCH** version (0.0.X): Bug fixes, backwards compatible
-
-### Version Format
-
-- Release builds: `X.Y.Z` (e.g., 2.0.0)
-- Snapshot builds: `X.Y.Z-SNAPSHOT` (e.g., 2.1.0-SNAPSHOT)
-
-The Maven build also appends a timestamp to the module version:
-```
-moduleVersion: 2.0.0.2025120910
-```
-
 ## Troubleshooting
 
-### Build Fails with "npm: not found"
+### Release workflow not triggered after Create Release
+The `RELEASE_PAT` secret may be missing or expired. Pushes using `GITHUB_TOKEN` don't trigger other workflows.
 
-The workflow installs Node.js automatically. If building locally, ensure Node.js 18+ is installed.
+### POM version mismatch error
+The Release workflow verifies that the POM version matches the tag. If they don't match, the Create Release workflow likely didn't run correctly. Check its logs.
 
-### Signing Fails
+### Module not signed
+Verify all four keystore secrets are set: `KEYSTORE_BASE64`, `KEYSTORE_ALIAS`, `KEYSTORE_STOREPASS`, `KEYSTORE_KEYPASS`.
 
-Check that all four keystore secrets are properly set in GitHub:
-- KEYSTORE_BASE64
-- KEYSTORE_ALIAS
-- KEYSTORE_STOREPASS
-- KEYSTORE_KEYPASS
-
-### Module Not Signed in Release
-
-If the release workflow runs but the module isn't signed:
-1. Verify all GitHub secrets are set correctly
-2. Check the workflow logs for signing errors
-3. Ensure the keystore is valid and not expired
-
-### Local Build Succeeds but CI Fails
-
-Common causes:
-1. Dependencies not in public Maven repositories
-2. Different Java versions (CI uses Java 17)
-3. Missing Node.js dependencies
-
-## Release Checklist
-
-Before creating a release:
-
-- [ ] Update version in `pom.xml`
-- [ ] Update CHANGELOG or release notes if applicable
-- [ ] Ensure all tests pass locally
-- [ ] Ensure CI is passing on main branch
-- [ ] Review and merge all pending PRs
-- [ ] Create and push version tag
-- [ ] Verify release artifacts are created
-- [ ] Test the signed .modl file in an Ignition gateway
-- [ ] Update documentation if needed
+### npm build fails
+Ensure Node.js 18+ is installed. The workflow sets this up automatically.
 
 ## Security Notes
 
 - Never commit the keystore file to the repository
 - Keep keystore passwords secure in GitHub Secrets
-- Rotate keystore passwords periodically
-- Use different keystores for development and production
-- Limit access to repository secrets to trusted maintainers
-
-## Support
-
-For issues with the release pipeline:
-1. Check GitHub Actions logs for detailed error messages
-2. Review this documentation
-3. Open an issue on GitHub with relevant logs
+- Use a fine-grained PAT with minimal permissions for `RELEASE_PAT`
+- Rotate credentials periodically

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,7 +70,7 @@ The workflow will:
 ### Pre-release
 
 1. Go to **Actions > Create Release > Run workflow**
-2. Set `bump_type` to `prerelease`
+2. Set `bump_type` to `prerelease` (no hyphen in the input value)
 3. Set `prerelease_type` to `alpha`, `beta`, or `rc`
 4. Click **Run workflow**
 
@@ -103,13 +103,9 @@ Set `dry_run: true` to preview what the workflow would do without making any cha
 
 ## Ignition Module Versioning
 
-Ignition requires a 4-part `MAJOR.MINOR.PATCH.BUILD` module version and cannot parse SemVer pre-release suffixes. The Release workflow handles this by:
+Per the [Ignition SDK docs](https://www.sdk-docs.inductiveautomation.com/docs/getting-started/anatomy-of-a-module/the-modulexml-file), module versions use the format `major.minor.revision[-rcX][-betaX]` (e.g., `2.1.0`, `2.1.0-rc1`, `2.1.0-beta2`).
 
-1. Stripping the pre-release suffix from the tag version
-2. Appending a UTC build timestamp
-3. Passing it to Maven via `-Dmodule.version=X.Y.Z.YYYYMMDDHH`
-
-Example: Tag `v2.1.0-beta.1` produces Ignition module version `2.1.0.2026020614`.
+The Release workflow passes the tag version to Maven via `-Dmodule.version`, which sets the `<moduleVersion>` in the built module.
 
 ## Build Artifacts
 

--- a/git-build/pom.xml
+++ b/git-build/pom.xml
@@ -20,6 +20,9 @@
         <maven.build.timestamp.format>yyyyMMddHH</maven.build.timestamp.format>
         <!-- Path to gateway web components -->
         <gateway.web.dir>${project.basedir}/../web/packages/gateway</gateway.web.dir>
+        <!-- Ignition module version: MAJOR.MINOR.PATCH.BUILD (4-part format required by Ignition) -->
+        <!-- CI can override with -Dmodule.version=X.Y.Z.BUILD to strip pre-release suffixes -->
+        <module.version>${project.parent.version}.${maven.build.timestamp}</module.version>
     </properties>
 
     <dependencies>
@@ -126,7 +129,7 @@
                     <moduleId>com.axone_io.ignition.git</moduleId>
                     <moduleName>${module-name}</moduleName>
                     <moduleDescription>${module-description}</moduleDescription>
-                    <moduleVersion>${project.parent.version}.${maven.build.timestamp}</moduleVersion>
+                    <moduleVersion>${module.version}</moduleVersion>
                     <requiredIgnitionVersion>${ignition-platform-version}</requiredIgnitionVersion>
                     <licenseFile>license.html</licenseFile>
 

--- a/git-build/pom.xml
+++ b/git-build/pom.xml
@@ -17,12 +17,11 @@
             UTC+2
         </timeZone>
         <locale>fr_FR</locale>
-        <maven.build.timestamp.format>yyyyMMddHH</maven.build.timestamp.format>
         <!-- Path to gateway web components -->
         <gateway.web.dir>${project.basedir}/../web/packages/gateway</gateway.web.dir>
-        <!-- Ignition module version: MAJOR.MINOR.PATCH.BUILD (4-part format required by Ignition) -->
-        <!-- CI can override with -Dmodule.version=X.Y.Z.BUILD to strip pre-release suffixes -->
-        <module.version>${project.parent.version}.${maven.build.timestamp}</module.version>
+        <!-- Ignition module version: major.minor.revision[-rcX][-betaX] per SDK docs -->
+        <!-- CI can override with -Dmodule.version=X.Y.Z -->
+        <module.version>${project.parent.version}</module.version>
     </properties>
 
     <dependencies>

--- a/git-client/src/main/java/com/axone_io/ignition/git/ClientScriptModule.java
+++ b/git-client/src/main/java/com/axone_io/ignition/git/ClientScriptModule.java
@@ -120,4 +120,9 @@ public class ClientScriptModule extends AbstractScriptModule {
     protected boolean importResourcesImpl(String projectName, boolean importTags, boolean importTheme, boolean importImages, String collisionPolicy) throws Exception {
         return rpc.importResources(projectName, importTags, importTheme, importImages, collisionPolicy);
     }
+
+    @Override
+    protected List<String> getGitTrackedProjectNamesImpl() {
+        return rpc.getGitTrackedProjectNames();
+    }
 }

--- a/git-common/src/main/java/com/axone_io/ignition/git/AbstractScriptModule.java
+++ b/git-common/src/main/java/com/axone_io/ignition/git/AbstractScriptModule.java
@@ -148,6 +148,11 @@ public abstract class AbstractScriptModule implements GitScriptInterface {
         return importResourcesImpl(projectName, importTags, importTheme, importImages, collisionPolicy);
     }
 
+    @Override
+    public List<String> getGitTrackedProjectNames() {
+        return getGitTrackedProjectNamesImpl();
+    }
+
     protected abstract boolean pullImpl(String projectName, String userName, boolean importTags, boolean importTheme,
                                         boolean importImages) throws Exception;
     protected abstract boolean pushImpl(String projectName, String userName) throws Exception;
@@ -170,5 +175,6 @@ public abstract class AbstractScriptModule implements GitScriptInterface {
     protected abstract boolean abortMergeImpl(String projectName) throws Exception;
     protected abstract boolean hasConflictsImpl(String projectName) throws Exception;
     protected abstract boolean importResourcesImpl(String projectName, boolean importTags, boolean importTheme, boolean importImages, String collisionPolicy) throws Exception;
+    protected abstract List<String> getGitTrackedProjectNamesImpl();
 
 }

--- a/git-common/src/main/java/com/axone_io/ignition/git/GitScriptInterface.java
+++ b/git-common/src/main/java/com/axone_io/ignition/git/GitScriptInterface.java
@@ -37,4 +37,7 @@ public interface GitScriptInterface {
     // Import resources from repo (without pull)
     boolean importResources(String projectName, boolean importTags, boolean importTheme, boolean importImages, String collisionPolicy) throws Exception;
 
+    // Multi-project awareness
+    List<String> getGitTrackedProjectNames();
+
 }

--- a/git-designer/src/main/java/com/axone_io/ignition/git/actions/GitBaseAction.java
+++ b/git-designer/src/main/java/com/axone_io/ignition/git/actions/GitBaseAction.java
@@ -112,6 +112,47 @@ public class GitBaseAction extends BaseAction {
         }
     }
 
+    /**
+     * Checks if multiple projects are Git-tracked on this gateway and warns the user
+     * that exported tags are gateway-scoped and will be committed to the current project's repo.
+     *
+     * @return true if the user confirms (or there's only one project), false if cancelled
+     */
+    private static boolean confirmExportMultiProject(String currentProject) {
+        try {
+            List<String> trackedProjects = rpc.getGitTrackedProjectNames();
+            if (trackedProjects.size() > 1) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("Multiple Git-tracked projects detected on this gateway:\n\n");
+                for (String name : trackedProjects) {
+                    if (name.equals(currentProject)) {
+                        sb.append("  \u2192 ").append(name).append(" (current)\n");
+                    } else {
+                        sb.append("     ").append(name).append("\n");
+                    }
+                }
+                sb.append("\nTags are gateway-scoped resources shared across all projects.\n");
+                sb.append("This export will write tags to the '").append(currentProject).append("' repository.\n\n");
+                sb.append("Make sure this is the correct project for tracking tag changes.\n");
+                sb.append("Consider configuring .tag-config.json with 'includedProviders'\n");
+                sb.append("to limit which tag providers each project exports.\n\n");
+                sb.append("Continue with export?");
+
+                int choice = JOptionPane.showConfirmDialog(
+                        context.getFrame(),
+                        sb.toString(),
+                        "Multi-Project Gateway Warning",
+                        JOptionPane.YES_NO_OPTION,
+                        JOptionPane.WARNING_MESSAGE);
+
+                return choice == JOptionPane.YES_OPTION;
+            }
+        } catch (Exception e) {
+            logger.warn("Unable to check for other Git-tracked projects: {}", e.getMessage());
+        }
+        return true;
+    }
+
     public static void handleAction(GitActionType type) {
         String message = BundleUtil.get().getStringLenient(type.baseBundleKey + ".ConfirmMessage");
         int messageType = JOptionPane.INFORMATION_MESSAGE;
@@ -131,6 +172,10 @@ public class GitBaseAction extends BaseAction {
                     showCommitPopup(projectName, userName);
                     break;
                 case EXPORT:
+                    if (!confirmExportMultiProject(projectName)) {
+                        confirmPopup = Boolean.FALSE;
+                        break;
+                    }
                     rpc.exportConfig(projectName);
                     break;
                 case REPO:

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/GatewayScriptModule.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/GatewayScriptModule.java
@@ -32,6 +32,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import simpleorm.dataset.SQuery;
+
 import static com.axone_io.ignition.git.managers.GitImageManager.exportImages;
 import static com.axone_io.ignition.git.managers.GitManager.*;
 import static com.axone_io.ignition.git.managers.GitTagManager.exportTag;
@@ -114,10 +116,14 @@ public class GatewayScriptModule extends AbstractScriptModule implements GitScri
     @Override
     protected boolean commitImpl(String projectName, String userName, String[] changes, String message) {
         try (Git git = getGit(getProjectFolderPath(projectName))) {
+            AddCommand addCommand = git.add();
+            AddCommand updateCommand = git.add().setUpdate(true);
             for (String change : changes) {
-                git.add().addFilepattern(change).call();
-                git.add().setUpdate(true).addFilepattern(change).call();
+                addCommand.addFilepattern(change);
+                updateCommand.addFilepattern(change);
             }
+            addCommand.call();
+            updateCommand.call();
 
             CommitCommand commit = git.commit().setMessage(message);
             setCommitAuthor(commit, projectName, userName);
@@ -856,5 +862,20 @@ public class GatewayScriptModule extends AbstractScriptModule implements GitScri
             logger.error("Error importing resources for project: " + projectName, e);
             throw new Exception("Failed to import resources: " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    protected List<String> getGitTrackedProjectNamesImpl() {
+        List<String> projectNames = new ArrayList<>();
+        try {
+            SQuery<GitProjectsConfigRecord> query = new SQuery<>(GitProjectsConfigRecord.META);
+            List<GitProjectsConfigRecord> records = context.getPersistenceInterface().query(query);
+            for (GitProjectsConfigRecord record : records) {
+                projectNames.add(record.getProjectName());
+            }
+        } catch (Exception e) {
+            logger.warn("Error querying Git-tracked projects.", e);
+        }
+        return projectNames;
     }
 }

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/GatewayScriptModule.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/GatewayScriptModule.java
@@ -116,14 +116,28 @@ public class GatewayScriptModule extends AbstractScriptModule implements GitScri
     @Override
     protected boolean commitImpl(String projectName, String userName, String[] changes, String message) {
         try (Git git = getGit(getProjectFolderPath(projectName))) {
-            AddCommand addCommand = git.add();
-            AddCommand updateCommand = git.add().setUpdate(true);
-            for (String change : changes) {
-                addCommand.addFilepattern(change);
-                updateCommand.addFilepattern(change);
+            if (changes != null && changes.length > 0) {
+                AddCommand addCommand = git.add();
+                AddCommand updateCommand = git.add().setUpdate(true);
+                boolean hasValidPattern = false;
+                for (String change : changes) {
+                    if (change != null && !change.isEmpty()) {
+                        addCommand.addFilepattern(change);
+                        updateCommand.addFilepattern(change);
+                        hasValidPattern = true;
+                    }
+                }
+                if (hasValidPattern) {
+                    addCommand.call();
+                    updateCommand.call();
+                } else {
+                    logger.warn("commitImpl called for project '" + projectName + "' with no valid file patterns; skipping add/update.");
+                    return false;
+                }
+            } else {
+                logger.warn("commitImpl called for project '" + projectName + "' with null or empty changes; skipping commit.");
+                return false;
             }
-            addCommand.call();
-            updateCommand.call();
 
             CommitCommand commit = git.commit().setMessage(message);
             setCommitAuthor(commit, projectName, userName);


### PR DESCRIPTION
### TL;DR

Overhaul the release process with automated versioning, improved workflows, and better pre-release support.

### What changed?

- Added a new `Create Release` workflow that automates version bumping, tagging, and release creation
- Enhanced the existing `Release` workflow to support pre-releases (alpha, beta, rc)
- Added proper SemVer handling with support for pre-release versions
- Implemented automatic changelog generation with categorized changes
- Added multi-project awareness with warnings when exporting tags in multi-project gateways
- Optimized Git commit operations by batching file additions
- Added a new `getGitTrackedProjectNames()` method to the script interface
- Updated documentation with clearer release instructions

### How to test?

1. Try the new release process:
   - Go to Actions > Create Release > Run workflow
   - Select a bump type (patch/minor/major/prerelease)
   - For pre-releases, select a type (alpha/beta/rc)
   - Use "dry run" to preview changes without pushing

2. Test multi-project tag export warning:
   - Set up Git tracking on multiple projects
   - Try to export tags from one project
   - Verify the warning appears with correct project information

### Why make this change?

- Simplify the release process with a single workflow that handles versioning
- Add proper support for pre-releases to enable better testing cycles
- Improve multi-project support by warning users about tag exports
- Enhance documentation to make the release process more accessible
- Optimize Git operations for better performance with large numbers of files