### PR TITLE
fix: workflow fixes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
           token: ${{ secrets.RELEASE_PAT }}
           fetch-depth: 0
 
@@ -167,7 +168,7 @@ jobs:
           echo "  2. Update web/packages/gateway/package.json to ${{ steps.new_version.outputs.version }}"
           echo "  3. Commit: 'chore(release): ${{ steps.new_version.outputs.version }}'"
           echo "  4. Tag: v${{ steps.new_version.outputs.version }}"
-          echo "  5. Push commit and tag to default branch"
+          echo "  5. Push commit and tag to ${{ github.ref }}"
           echo "  6. release.yml will trigger to build, sign, and publish"
 
       - name: Commit, tag, and push
@@ -179,6 +180,6 @@ jobs:
           git add -A
           git commit -m "chore(release): ${{ steps.new_version.outputs.version }}"
           git tag "v${{ steps.new_version.outputs.version }}"
-          git push origin ${{ github.event.repository.default_branch }} --follow-tags
+          git push origin HEAD:${{ github.ref }} --follow-tags
 
           echo "Pushed v${{ steps.new_version.outputs.version }} - release.yml will now build and publish"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
           retention-days: 90
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           draft: false
           prerelease: ${{ steps.version.outputs.is_prerelease }}

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
@@ -445,8 +445,10 @@ public class GitTagManager {
 
             } else if (TAG_TYPE_UDT_DEF.equals(tagType)) {
                 // UDT type definitions go under _types_/
-                Path typesDir = getTypesDir(parentDir);
-                writeTagFile(typesDir, name, tagJson);
+                // If we're already under _types_/, preserve the current directory hierarchy
+                // Otherwise, move to the root _types_/ directory
+                Path targetDir = isUnderTypesDir(parentDir) ? parentDir : getTypesDir(parentDir);
+                writeTagFile(targetDir, name, tagJson);
 
             } else {
                 // All other tags: AtomicTag, UdtInstance, OPC, Expression, etc.
@@ -455,6 +457,20 @@ public class GitTagManager {
         } catch (IOException e) {
             logger.warn("Error writing tag '" + name + "' to " + parentDir, e);
         }
+    }
+
+    /**
+     * Checks if the given path is already under the {@code _types_/} directory.
+     */
+    private static boolean isUnderTypesDir(Path path) {
+        Path current = path;
+        while (current != null) {
+            if (current.getFileName() != null && current.getFileName().toString().equals(TYPES_DIR_NAME)) {
+                return true;
+            }
+            current = current.getParent();
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Pin `softprops/action-gh-release` to a specific commit SHA for security
- Fix `create-release.yml` to use `github.ref` instead of default branch, allowing releases from non-default branches
- Fix UDT type export to preserve directory hierarchy when already under `_types_/` directory

## Test plan
- [ ] Verify release workflow triggers correctly on tag push
- [ ] Verify create-release workflow pushes to the correct ref
- [ ] Test tag export with nested UDT types to confirm hierarchy is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)