### PR TITLE
feat: add defaults for project config commissioning values

### DIFF
--- a/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/GitCommissioningConfig.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/GitCommissioningConfig.java
@@ -63,14 +63,14 @@ public class GitCommissioningConfig {
         this.repoBranch = projectConfig.getRepo_branch();
         this.ignitionProjectName = projectConfig.getIgnition_projectName();
         this.ignitionUserName = projectConfig.getIgnition_userName();
-        this.ignitionProjectInheritable = projectConfig.getIgnition_inheritable();
+        this.ignitionProjectInheritable = Boolean.TRUE.equals(projectConfig.getIgnition_inheritable());
         this.ignitionProjectParentName = projectConfig.getIgnition_parentName();
         this.userName = projectConfig.getUser_name();
         this.userEmail = projectConfig.getUser_email();
         this.userPassword = projectConfig.getUser_password();
-        this.importImages = projectConfig.getCommissioning_importImages();
-        this.importTags = projectConfig.getCommissioning_importTags();
-        this.importThemes = projectConfig.getCommissioning_importThemes();
+        this.importImages = Boolean.TRUE.equals(projectConfig.getCommissioning_importImages());
+        this.importTags = Boolean.TRUE.equals(projectConfig.getCommissioning_importTags());
+        this.importThemes = Boolean.TRUE.equals(projectConfig.getCommissioning_importThemes());
         this.initDefaultBranch = projectConfig.getInitDefaultBranch();
     }
 


### PR DESCRIPTION
### TL;DR

Added null-safe boolean conversion for project configuration properties to prevent potential null pointer exceptions.

### What changed?

Modified the `loadFromProjectConfig` method in `GitCommissioningConfig` to use `Boolean.TRUE.equals()` for four boolean properties:
- `ignitionProjectInheritable`
- `importImages` 
- `importTags`
- `importThemes`

This ensures these properties default to `false` when the configuration values are `null` instead of causing runtime errors.

### How to test?

1. Test with project configurations where the boolean fields are explicitly set to `true`, `false`, and `null`
2. Verify that `null` values are properly handled and default to `false`
3. Confirm that explicit `true` and `false` values are preserved correctly
4. Run existing commissioning workflows to ensure no regression

### Why make this change?

This change prevents `NullPointerException` errors when the project configuration contains `null` values for boolean properties. The `Boolean.TRUE.equals()` pattern is a defensive programming practice that safely handles `null` values by treating them as `false`, making the configuration loading more robust.