### PR TITLE
feat: add yaml configuration for the handling of active branch persistence between gateway restarts

### DIFF
--- a/docker/gw-init/git.yaml
+++ b/docker/gw-init/git.yaml
@@ -10,6 +10,7 @@
   commissioning_importThemes: true
   commissioning_importTags: true
   commissioning_importImages: true
+  commissioning_enforceBranch: false
   initDefaultBranch: main
 - repo_uri: https://github.com/WHK01/whk-distillery01-ignition-global.git
   repo_branch: development
@@ -23,3 +24,4 @@
   commissioning_importThemes: true
   commissioning_importTags: true
   commissioning_importImages: true
+  commissioning_enforceBranch: false

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/GitCommissioningConfig.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/GitCommissioningConfig.java
@@ -55,6 +55,9 @@ public class GitCommissioningConfig {
     private boolean importThemes = false;
     @Getter
     @Setter
+    private boolean enforceBranch = true;
+    @Getter
+    @Setter
     private String initDefaultBranch;
 
     public void loadFromProjectConfig(ProjectConfig projectConfig) {
@@ -71,6 +74,8 @@ public class GitCommissioningConfig {
         this.importImages = Boolean.TRUE.equals(projectConfig.getCommissioning_importImages());
         this.importTags = Boolean.TRUE.equals(projectConfig.getCommissioning_importTags());
         this.importThemes = Boolean.TRUE.equals(projectConfig.getCommissioning_importThemes());
+        this.enforceBranch = projectConfig.getCommissioning_enforceBranch() == null
+                || Boolean.TRUE.equals(projectConfig.getCommissioning_enforceBranch());
         this.initDefaultBranch = projectConfig.getInitDefaultBranch();
     }
 

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/ProjectConfig.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/ProjectConfig.java
@@ -47,5 +47,8 @@ public class ProjectConfig {
     @Getter
     @Setter
     private Boolean commissioning_importImages;
+    @Getter
+    @Setter
+    private Boolean commissioning_enforceBranch;
 
 }

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/utils/GitCommissioningUtils.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/utils/GitCommissioningUtils.java
@@ -181,24 +181,29 @@ public class GitCommissioningUtils {
             setAuthentication(fetch, projectName, config.getIgnitionUserName());
             fetch.call();
 
-            // 3. Switch branch if needed
-            if (!currentBranch.equals(configuredBranch)) {
-                logger.info("Switching project '" + projectName + "' from branch '" + currentBranch + "' to configured branch '" + configuredBranch + "'.");
-                boolean localBranchExists = git.branchList().call().stream()
-                        .anyMatch(ref -> ref.getName().equals("refs/heads/" + configuredBranch));
+            // 3. Switch branch if needed (and enforceBranch is enabled)
+            if (config.isEnforceBranch()) {
+                if (!currentBranch.equals(configuredBranch)) {
+                    logger.info("Switching project '" + projectName + "' from branch '" + currentBranch + "' to configured branch '" + configuredBranch + "'.");
+                    boolean localBranchExists = git.branchList().call().stream()
+                            .anyMatch(ref -> ref.getName().equals("refs/heads/" + configuredBranch));
 
-                CheckoutCommand checkout = git.checkout().setName(configuredBranch);
-                if (!localBranchExists) {
-                    checkout.setCreateBranch(true)
-                            .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
-                            .setStartPoint(remoteName + "/" + configuredBranch);
+                    CheckoutCommand checkout = git.checkout().setName(configuredBranch);
+                    if (!localBranchExists) {
+                        checkout.setCreateBranch(true)
+                                .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
+                                .setStartPoint(remoteName + "/" + configuredBranch);
+                    }
+                    checkout.call();
                 }
-                checkout.call();
+            } else {
+                logger.info("Skipping branch switch for project '" + projectName + "' because commissioning_enforceBranch is false. Staying on branch '" + currentBranch + "'.");
             }
 
             // 4. Pull latest
-            logger.info("Pulling latest changes for project '" + projectName + "' on branch '" + configuredBranch + "'...");
-            PullCommand pull = git.pull().setRemote(remoteName);
+            String activeBranch = git.getRepository().getBranch();
+            logger.info("Pulling latest changes for project '" + projectName + "' on branch '" + activeBranch + "'...");
+            PullCommand pull = git.pull().setRemote(remoteName).setRemoteBranchName(activeBranch);
             setAuthentication(pull, projectName, config.getIgnitionUserName());
             PullResult pullResult = pull.call();
             logger.info("Pull result for project '" + projectName + "': " + (pullResult.isSuccessful() ? "success" : "failed"));
@@ -347,7 +352,8 @@ public class GitCommissioningUtils {
                 yamlKey.equals("ignition_inheritable") || yamlKey.equals("ignition_parentName") ||
                 yamlKey.equals("user_name") || yamlKey.equals("user_email") ||
                 yamlKey.equals("user_password") || yamlKey.equals("commissioning_importThemes") ||
-                yamlKey.equals("commissioning_importTags") || yamlKey.equals("commissioning_importImages")) {
+                yamlKey.equals("commissioning_importTags") || yamlKey.equals("commissioning_importImages") ||
+                yamlKey.equals("commissioning_enforceBranch")) {
             return yamlKey; // Your field names already match the YAML keys
         }
 


### PR DESCRIPTION
## Add branch enforcement control for git commissioning

This change introduces a new `commissioning_enforceBranch` configuration option that allows users to control whether the git commissioning process should automatically switch to the configured branch or remain on the current branch.

### Changes

- Added `commissioning_enforceBranch` field to `ProjectConfig` and `GitCommissioningConfig` classes
- Updated YAML configuration to include the new `commissioning_enforceBranch` parameter (defaults to `false` in the example)
- Modified branch switching logic in `GitCommissioningUtils` to respect the `enforceBranch` setting
- When `enforceBranch` is disabled, the system logs a message and skips branch switching while still pulling latest changes from the current branch
- Updated field validation to recognize the new configuration parameter

The default behavior maintains backward compatibility by defaulting `enforceBranch` to `true` when not explicitly configured.