### PR TITLE
feat(ui): expose production mode settings in Gateway config page

### DIFF
--- a/git-gateway/src/main/java/com/axone_io/ignition/git/web/api/GitRoutes.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/web/api/GitRoutes.java
@@ -173,6 +173,9 @@ public class GitRoutes {
                         obj.addProperty("id", p.getId());
                         obj.addProperty("projectName", p.getProjectName());
                         obj.addProperty("uri", p.getURI());
+                        obj.addProperty("productionMode", p.getProductionMode());
+                        obj.addProperty("productionBranch", p.getProductionBranch());
+                        obj.addProperty("productionTagPattern", p.getProductionTagPattern());
                         return obj;
                     })
                     .collect(Collectors.toList());
@@ -203,6 +206,9 @@ public class GitRoutes {
             obj.addProperty("id", project.getId());
             obj.addProperty("projectName", project.getProjectName());
             obj.addProperty("uri", project.getURI());
+            obj.addProperty("productionMode", project.getProductionMode());
+            obj.addProperty("productionBranch", project.getProductionBranch());
+            obj.addProperty("productionTagPattern", project.getProductionTagPattern());
             return obj;
         } catch (Exception e) {
             logger.error("Error fetching project", e);
@@ -264,6 +270,7 @@ public class GitRoutes {
 
             record.setProjectName(projectName);
             record.setURI(uri);
+            applyProductionFields(record, body);
 
             req.getGatewayContext().getPersistenceInterface().save(record);
 
@@ -272,6 +279,9 @@ public class GitRoutes {
             response.addProperty("id", record.getId());
             response.addProperty("projectName", record.getProjectName());
             response.addProperty("uri", record.getURI());
+            response.addProperty("productionMode", record.getProductionMode());
+            response.addProperty("productionBranch", record.getProductionBranch());
+            response.addProperty("productionTagPattern", record.getProductionTagPattern());
             return response;
         } catch (Exception e) {
             logger.error("Error creating project", e);
@@ -341,6 +351,7 @@ public class GitRoutes {
 
             record.setProjectName(projectName);
             record.setURI(uri);
+            applyProductionFields(record, body);
 
             req.getGatewayContext().getPersistenceInterface().save(record);
 
@@ -348,6 +359,9 @@ public class GitRoutes {
             response.addProperty("id", record.getId());
             response.addProperty("projectName", record.getProjectName());
             response.addProperty("uri", record.getURI());
+            response.addProperty("productionMode", record.getProductionMode());
+            response.addProperty("productionBranch", record.getProductionBranch());
+            response.addProperty("productionTagPattern", record.getProductionTagPattern());
             return response;
         } catch (Exception e) {
             logger.error("Error updating project", e);
@@ -383,6 +397,24 @@ public class GitRoutes {
             JsonObject error = new JsonObject();
             error.addProperty("error", e.getMessage());
             return error;
+        }
+    }
+
+    private static void applyProductionFields(GitProjectsConfigRecord record, JsonObject body) {
+        if (body.has("productionMode") && body.get("productionMode").isJsonPrimitive()) {
+            record.setProductionMode(body.get("productionMode").getAsBoolean());
+        }
+        if (body.has("productionBranch") && body.get("productionBranch").isJsonPrimitive()) {
+            String branch = body.get("productionBranch").getAsString();
+            record.setProductionBranch(branch == null || branch.trim().isEmpty() ? null : branch.trim());
+        } else if (body.has("productionBranch") && body.get("productionBranch").isJsonNull()) {
+            record.setProductionBranch(null);
+        }
+        if (body.has("productionTagPattern") && body.get("productionTagPattern").isJsonPrimitive()) {
+            String pattern = body.get("productionTagPattern").getAsString();
+            record.setProductionTagPattern(pattern == null || pattern.trim().isEmpty() ? null : pattern.trim());
+        } else if (body.has("productionTagPattern") && body.get("productionTagPattern").isJsonNull()) {
+            record.setProductionTagPattern(null);
         }
     }
 

--- a/web/packages/gateway/src/GitProjectsConfig.tsx
+++ b/web/packages/gateway/src/GitProjectsConfig.tsx
@@ -6,6 +6,9 @@ interface GitProject {
   id: number;
   projectName: string;
   uri: string;
+  productionMode?: boolean;
+  productionBranch?: string | null;
+  productionTagPattern?: string | null;
 }
 
 interface State {
@@ -57,7 +60,14 @@ export class GitProjectsConfig extends Component<{}, State> {
 
   handleNew = () => {
     this.setState({
-      editing: { id: 0, projectName: '', uri: '' },
+      editing: {
+        id: 0,
+        projectName: '',
+        uri: '',
+        productionMode: false,
+        productionBranch: '',
+        productionTagPattern: '',
+      },
       isNew: true
     });
   };
@@ -108,7 +118,7 @@ export class GitProjectsConfig extends Component<{}, State> {
     this.setState({ editing: null, isNew: false });
   };
 
-  handleChange = (field: keyof GitProject, value: string) => {
+  handleChange = (field: keyof GitProject, value: string | boolean) => {
     this.setState(state => ({
       editing: state.editing ? { ...state.editing, [field]: value } : null
     }));
@@ -147,6 +157,42 @@ export class GitProjectsConfig extends Component<{}, State> {
               />
               <small>Use https:// for username/password or git@github.com: for SSH</small>
             </div>
+            <fieldset className="form-fieldset">
+              <legend>Production Mode</legend>
+              <div className="form-group">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={!!editing.productionMode}
+                    onChange={(e) => this.handleChange('productionMode', e.target.checked)}
+                  />
+                  {' '}Enable production mode
+                </label>
+                <small>Adds safety guards: pull checklist, push warnings, branch-switch block, and hotfix workflow on commits.</small>
+              </div>
+              <div className="form-group">
+                <label>Production Branch:</label>
+                <input
+                  type="text"
+                  value={editing.productionBranch ?? ''}
+                  onChange={(e) => this.handleChange('productionBranch', e.target.value)}
+                  placeholder="main"
+                  disabled={!editing.productionMode}
+                />
+                <small>The protected branch (e.g. main, master, production).</small>
+              </div>
+              <div className="form-group">
+                <label>Production Tag Pattern:</label>
+                <input
+                  type="text"
+                  value={editing.productionTagPattern ?? ''}
+                  onChange={(e) => this.handleChange('productionTagPattern', e.target.value)}
+                  placeholder="v*"
+                  disabled={!editing.productionMode}
+                />
+                <small>Wildcard (v*, release-?) or regex (^v\d+\.\d+\.\d+$). Leave blank to skip tag validation.</small>
+              </div>
+            </fieldset>
             <div className="button-group">
               <button onClick={this.handleSave} className="btn-primary">Save</button>
               <button onClick={this.handleCancel} className="btn-secondary">Cancel</button>
@@ -162,13 +208,14 @@ export class GitProjectsConfig extends Component<{}, State> {
                   <th>Project Name</th>
                   <th>Repository URI</th>
                   <th>Auth Type</th>
+                  <th>Production</th>
                   <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {projects.length === 0 ? (
                   <tr>
-                    <td colSpan={4} className="empty">
+                    <td colSpan={5} className="empty">
                       No projects configured. Click "Add New Project" to get started.
                     </td>
                   </tr>
@@ -178,6 +225,13 @@ export class GitProjectsConfig extends Component<{}, State> {
                       <td>{project.projectName}</td>
                       <td>{project.uri}</td>
                       <td>{project.uri.toLowerCase().startsWith('http') ? 'HTTPS' : 'SSH'}</td>
+                      <td>
+                        {project.productionMode ? (
+                          <span className="prod-badge" title={`branch: ${project.productionBranch || '(unset)'}\ntag pattern: ${project.productionTagPattern || '(none)'}`}>PRODUCTION</span>
+                        ) : (
+                          <span className="prod-off">—</span>
+                        )}
+                      </td>
                       <td>
                         <button
                           onClick={() => this.handleEdit(project)}

--- a/web/packages/gateway/src/config.css
+++ b/web/packages/gateway/src/config.css
@@ -185,3 +185,30 @@
 .button-group {
   margin-top: 20px;
 }
+
+.form-fieldset {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 10px 15px;
+  margin-top: 15px;
+}
+
+.form-fieldset legend {
+  font-weight: bold;
+  padding: 0 6px;
+}
+
+.prod-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  background-color: #d9534f;
+  color: #fff;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.prod-off {
+  color: #999;
+}

--- a/web/packages/gateway/src/config.css
+++ b/web/packages/gateway/src/config.css
@@ -91,7 +91,7 @@
   color: #555;
 }
 
-.form-group input,
+.form-group input:not([type="checkbox"]):not([type="radio"]),
 .form-group select,
 .form-group textarea {
   width: 100%;
@@ -102,12 +102,19 @@
   box-sizing: border-box;
 }
 
-.form-group input:focus,
+.form-group input:not([type="checkbox"]):not([type="radio"]):focus,
 .form-group select:focus,
 .form-group textarea:focus {
   outline: none;
   border-color: #5cb85c;
   box-shadow: 0 0 0 2px rgba(92, 184, 92, 0.2);
+}
+
+.form-group input[type="checkbox"],
+.form-group input[type="radio"] {
+  width: auto;
+  margin-right: 6px;
+  vertical-align: middle;
 }
 
 .form-group small {


### PR DESCRIPTION
## Summary
- Surface `production_mode` / `production_branch` / `production_tagPattern` in the **Git Projects Configuration** page so production gateways configured via the UI no longer need a `git.yaml` + restart to enable production mode.
- REST endpoints (`GET/POST/PUT /data/git/projects`) now serialize the three fields; new `applyProductionFields` helper accepts them optionally so existing API clients keep working.
- UI: edit/new form gets a **Production Mode** fieldset (checkbox + branch + tag pattern; branch/pattern disabled until enabled). List view gets a **Production** column with a red badge for protected projects.

## Why
Projects added through the UI write directly to the IDB (`GitProjectsConfigRecord`) but the form never exposed the three production fields, so the *only* way to enable production mode on those projects was to drop a `git.yaml` next to the gateway and restart — awkward on Windows production gateways. The DB columns already exist; this PR just wires the missing UI/REST path.

## Test plan
- [ ] Build verified locally: `npm run build` ✅, `mvn clean package -DskipTests` ✅
- [ ] Install fresh `Git-unsigned.modl` on a non-prod gateway
- [ ] Edit an existing project → enable production mode → set branch + tag pattern → Save → reload page → confirm fields persisted
- [ ] Confirm `PRODUCTION` badge renders in list view
- [ ] Open Designer for that project → confirm red **PRODUCTION** badge appears in status bar
- [ ] Verify pull triggers safety checklist, branch switch is blocked, commit on production branch triggers hotfix workflow
- [ ] Disable production mode via UI → confirm safety guards turn off
- [ ] Existing `git.yaml`-driven configs still merge correctly on gateway restart (non-regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)