### PR TITLE
fix(tags): percent-encode reserved chars in tag-export filenames (Windows)

### DIFF
--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
@@ -68,6 +68,57 @@ public class GitTagManager {
     private static final String TAG_TYPE_FOLDER = "Folder";
     private static final String TAG_TYPE_PROVIDER = "Provider";
 
+    // Reserved on Windows: < > : " / \ | ? *. Encoding these (plus control chars and %)
+    // lets tag names round-trip through the filesystem on every OS.
+    private static final String FS_RESERVED_CHARS = "<>:\"/\\|?*";
+
+    /**
+     * Encodes a tag name so it is safe to use as a filesystem path segment on any OS.
+     * Reserved characters, control characters, and the percent sign itself are
+     * replaced with {@code %XX} hex escapes. Names with only safe characters are
+     * returned unchanged so existing repositories do not churn.
+     */
+    static String encodeFsName(String name) {
+        if (name == null || name.isEmpty()) return name;
+        StringBuilder sb = new StringBuilder(name.length());
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (c == '%' || c < 0x20 || FS_RESERVED_CHARS.indexOf(c) >= 0) {
+                sb.append(String.format("%%%02X", (int) c));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Reverses {@link #encodeFsName(String)} when reading a tag name from a path
+     * segment. Unrecognised {@code %XX} sequences are left intact so legacy names
+     * that happen to contain a literal {@code %} still read correctly.
+     */
+    static String decodeFsName(String fsName) {
+        if (fsName == null || fsName.indexOf('%') < 0) return fsName;
+        StringBuilder sb = new StringBuilder(fsName.length());
+        int i = 0;
+        while (i < fsName.length()) {
+            char c = fsName.charAt(i);
+            if (c == '%' && i + 2 < fsName.length()) {
+                try {
+                    int code = Integer.parseInt(fsName.substring(i + 1, i + 3), 16);
+                    sb.append((char) code);
+                    i += 3;
+                    continue;
+                } catch (NumberFormatException ignored) {
+                    // not a valid escape — fall through and keep literal
+                }
+            }
+            sb.append(c);
+            i++;
+        }
+        return sb.toString();
+    }
+
     // ========================== IMPORT ==========================
 
     /**
@@ -357,17 +408,20 @@ public class GitTagManager {
         if (entries == null) return tags;
 
         for (File entry : entries) {
-            String name = entry.getName();
+            String fsName = entry.getName();
 
-            // Skip config and tag-groups files (tag groups are imported separately)
-            if (name.equals(TAG_CONFIG_FILENAME)) continue;
-            if (name.equals(GitTagGroupManager.TAG_GROUPS_FILENAME)) continue;
+            // Skip config and tag-groups files (tag groups are imported separately).
+            // These constants contain only safe characters, so compare against the raw filesystem name.
+            if (fsName.equals(TAG_CONFIG_FILENAME)) continue;
+            if (fsName.equals(GitTagGroupManager.TAG_GROUPS_FILENAME)) continue;
 
             // Optionally skip _types_ directory (handled separately for UDT ordering)
-            if (skipTypesDir && name.equals(TYPES_DIR_NAME)) continue;
+            if (skipTypesDir && fsName.equals(TYPES_DIR_NAME)) continue;
 
             if (entry.isDirectory()) {
-                // Recurse into subdirectory — this is a folder node
+                // Recurse into subdirectory — this is a folder node.
+                // Decode the directory name to recover the original tag name.
+                String name = decodeFsName(fsName);
                 JsonObject childTags = readTagsFromDirectory(entry.toPath(), false);
                 JsonObject folder = new JsonObject();
                 folder.addProperty("name", name);
@@ -382,8 +436,9 @@ public class GitTagManager {
                 }
                 tags.add(name, folder);
 
-            } else if (name.endsWith(".json")) {
-                String tagName = FilenameUtils.removeExtension(name);
+            } else if (fsName.endsWith(".json")) {
+                // Strip extension first, then decode — the .json suffix is always literal.
+                String tagName = decodeFsName(FilenameUtils.removeExtension(fsName));
                 try {
                     String content = Files.readString(entry.toPath());
                     JsonObject tagObj = TAG_GSON.fromJson(content, JsonObject.class);
@@ -531,8 +586,8 @@ public class GitTagManager {
 
         try {
             if (TAG_TYPE_FOLDER.equals(tagType) || TAG_TYPE_PROVIDER.equals(tagType)) {
-                // Create subdirectory and recurse
-                Path subDir = parentDir.resolve(name);
+                // Create subdirectory and recurse — encode name for filesystem safety
+                Path subDir = parentDir.resolve(encodeFsName(name));
                 Files.createDirectories(subDir);
                 writeTagsRecursively(tagJson, subDir, excludedPaths, relativePath);
 
@@ -601,7 +656,7 @@ public class GitTagManager {
         JsonObject toWrite = tagJson.deepCopy();
         toWrite.remove("name");
 
-        Path file = dir.resolve(tagName + ".json");
+        Path file = dir.resolve(encodeFsName(tagName) + ".json");
         String json = TAG_GSON.toJson(JsonUtilities.createDeterministicCopy(toWrite));
         Files.writeString(file, json);
     }

--- a/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagManagerTest.java
+++ b/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagManagerTest.java
@@ -1,0 +1,69 @@
+package com.axone_io.ignition.git.managers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class GitTagManagerTest {
+
+    @Test
+    public void encodeFsName_leavesSafeNamesUnchanged() {
+        assertEquals("Tank1_Level", GitTagManager.encodeFsName("Tank1_Level"));
+        assertEquals("ns2_v1.0", GitTagManager.encodeFsName("ns2_v1.0"));
+        assertEquals("foo-bar baz", GitTagManager.encodeFsName("foo-bar baz"));
+    }
+
+    @Test
+    public void encodeFsName_escapesWindowsReservedChars() {
+        // The actual failing case from production
+        assertEquals("_0%3A0%3Awhk-development-gw",
+                GitTagManager.encodeFsName("_0:0:whk-development-gw"));
+        // Each Windows-reserved char must be escaped
+        assertEquals("a%3Cb%3Ec%3Ad%22e%2Ff%5Cg%7Ch%3Fi%2Aj",
+                GitTagManager.encodeFsName("a<b>c:d\"e/f\\g|h?i*j"));
+    }
+
+    @Test
+    public void encodeFsName_escapesPercentItself() {
+        // Percent must be escaped first so decoding is unambiguous
+        assertEquals("100%25", GitTagManager.encodeFsName("100%"));
+        assertEquals("%25%3A", GitTagManager.encodeFsName("%:"));
+    }
+
+    @Test
+    public void encodeFsName_handlesNullAndEmpty() {
+        assertNull(GitTagManager.encodeFsName(null));
+        assertEquals("", GitTagManager.encodeFsName(""));
+    }
+
+    @Test
+    public void decodeFsName_reversesEncoding() {
+        String[] originals = {
+                "_0:0:whk-development-gw",
+                "ns=2;s=Foo:Bar",
+                "100%",
+                "a<b>c:d\"e/f\\g|h?i*j",
+                "Tank1_Level",
+                ""
+        };
+        for (String original : originals) {
+            String roundtrip = GitTagManager.decodeFsName(GitTagManager.encodeFsName(original));
+            assertEquals("round-trip failed for: " + original, original, roundtrip);
+        }
+    }
+
+    @Test
+    public void decodeFsName_leavesUnknownPercentsIntact() {
+        // Legacy names with bare % that aren't valid hex escapes should pass through
+        assertEquals("not%xxhex", GitTagManager.decodeFsName("not%xxhex"));
+        assertEquals("trailing%", GitTagManager.decodeFsName("trailing%"));
+        assertEquals("trailing%2", GitTagManager.decodeFsName("trailing%2"));
+    }
+
+    @Test
+    public void decodeFsName_handlesNullAndEmpty() {
+        assertNull(GitTagManager.decodeFsName(null));
+        assertEquals("", GitTagManager.decodeFsName(""));
+    }
+}


### PR DESCRIPTION
## Summary
- Tag export crashes on Windows gateways with `InvalidPathException: Illegal char <:>` when any tag name contains characters reserved on NTFS (`< > : " / \ | ? *`). Real-world failure in production: tag name `_0:0:whk-development-gw` (an OPC/UA path) blocks the entire export.
- Fix percent-encodes reserved characters when writing tag folders/files, and percent-decodes when reading them back. Names with only safe characters are byte-identical on disk (zero churn for existing repos).

## Why this approach
- The naïve "strip or replace" approach is destructive — exporting then re-importing would silently rename live tags. Percent-encoding is reversible, so the round-trip stays lossless.
- Encoding `%` itself (along with reserved chars) keeps decoding unambiguous. Legacy filenames that happen to contain a literal `%` not followed by hex still decode cleanly because malformed escapes are passed through.

## What changed
- `GitTagManager.encodeFsName` / `decodeFsName` — new helpers (4 callers).
- `writeTagNode` (folder branch) and `writeTagFile` — encode before `Path.resolve`.
- `readTagsFromDirectory` — decode the recovered name from directory/filename so the JSON `name` field reflects the original tag.
- New `GitTagManagerTest` (7 tests, all passing): production failure case, every Windows reserved char, percent-escape behaviour, full round-trip, null/empty, and lenient decode of malformed escapes.

## Verification
- `mvn -pl git-gateway test` → **57/57 passing** (including the 7 new ones)
- `mvn clean package -DskipTests` → produces `Git-unsigned.modl`
- Existing repos with tag names containing only safe chars produce byte-identical disk output (verified by inspection — encoding is a no-op on safe inputs).

## Test plan (manual on Windows prod gateway)
- [ ] Install fresh `Git-unsigned.modl`
- [ ] Run **Export Tags** from Designer for the project that previously crashed → expect success, no `InvalidPathException`
- [ ] Inspect the `tags/` directory in the repo — colon-bearing tag names appear as `_0%3A0%3Awhk-development-gw.json`
- [ ] **Import Tags** on a different gateway / fresh checkout → confirm the tag re-imports with the original name `_0:0:whk-development-gw` (not the encoded form)
- [ ] Existing tags without reserved chars: confirm filenames unchanged on disk after re-export
- [ ] Tag-pattern validation in production mode (`v*`, regex) still works — only tag *file* names are affected, not git tag refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)