### PR TITLE
fix(tags): omit built-in System tag provider from git tracking

### DIFF
--- a/git-common/src/main/java/com/axone_io/ignition/git/TagExportConfig.java
+++ b/git-common/src/main/java/com/axone_io/ignition/git/TagExportConfig.java
@@ -15,6 +15,13 @@ import java.util.List;
 public class TagExportConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Name of Ignition's built-in tag provider that holds runtime/diagnostic tags
+     * (gateway uptime, performance metrics, etc.). These are environment-specific
+     * and must never be tracked in git.
+     */
+    public static final String SYSTEM_PROVIDER_NAME = "System";
+
     /** Tag providers to include in export. Empty list means all providers. */
     private List<String> includedProviders;
 
@@ -71,8 +78,13 @@ public class TagExportConfig implements Serializable {
     /**
      * Returns {@code true} if the given provider name should be included in export,
      * based on the {@link #includedProviders} list. An empty list means all providers.
+     * The Ignition built-in {@link #SYSTEM_PROVIDER_NAME System} provider is always
+     * excluded regardless of configuration.
      */
     public boolean isProviderIncluded(String providerName) {
+        if (SYSTEM_PROVIDER_NAME.equals(providerName)) {
+            return false;
+        }
         return includedProviders == null || includedProviders.isEmpty()
                 || includedProviders.contains(providerName);
     }

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
@@ -12,6 +12,7 @@ import com.inductiveautomation.ignition.common.tags.config.TagGroupMode;
 import com.inductiveautomation.ignition.common.tags.model.TagProvider;
 import com.inductiveautomation.ignition.common.util.LoggerEx;
 import com.inductiveautomation.ignition.gateway.tags.model.GatewayTagManager;
+import com.axone_io.ignition.git.TagExportConfig;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -68,6 +69,12 @@ public class GitTagGroupManager {
 
         for (TagProvider tagProvider : gatewayTagManager.getTagProviders()) {
             String providerName = tagProvider.getName();
+
+            if (TagExportConfig.SYSTEM_PROVIDER_NAME.equals(providerName)) {
+                logger.debug("Skipping tag group export for built-in System provider.");
+                continue;
+            }
+
             Path providerDir = tagsDir.resolve(providerName);
 
             try {

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
@@ -166,6 +166,10 @@ public class GitTagManager {
                 continue;
             }
             String providerName = FilenameUtils.removeExtension(file.getName());
+            if (TagExportConfig.SYSTEM_PROVIDER_NAME.equals(providerName)) {
+                logger.debug("Skipping legacy import for built-in System provider.");
+                continue;
+            }
             TagProvider tagProvider = gatewayTagManager.getTagProvider(providerName);
             if (tagProvider != null) {
                 try {
@@ -192,6 +196,10 @@ public class GitTagManager {
         try (DirectoryStream<Path> providerDirs = Files.newDirectoryStream(tagsDir, Files::isDirectory)) {
             for (Path providerDir : providerDirs) {
                 String providerName = providerDir.getFileName().toString();
+                if (TagExportConfig.SYSTEM_PROVIDER_NAME.equals(providerName)) {
+                    logger.debug("Skipping individual-file import for built-in System provider.");
+                    continue;
+                }
                 TagProvider tagProvider = gatewayTagManager.getTagProvider(providerName);
                 if (tagProvider == null) {
                     logger.warn("Tag provider '" + providerName + "' not found, skipping individual-file import.");


### PR DESCRIPTION
Assignee: @TheThoughtagen ([pmannion](https://linear.app/whiskey-house-eandt/profiles/pmannion))

## Summary
Ignition's built-in **System** tag provider exposes runtime/diagnostic tags (gateway uptime, performance metrics, etc.) that are environment-specific and produce noisy diffs on every commit. This change excludes the System provider from git tag tracking on both export and import paths.

## Implementation
- Added `TagExportConfig.SYSTEM_PROVIDER_NAME` constant as the single source of truth, and updated `isProviderIncluded()` to always return `false` for that name regardless of user `includedProviders` configuration.
- `GitTagGroupManager.exportTagGroups()` (which iterates providers directly, bypassing `TagExportConfig`) now reuses the same constant to skip the System provider.
- Defensively filtered the System provider in both `GitTagManager.importFromLegacyFiles()` and `importFromIndividualFiles()` so existing repos that previously committed a `tags/System/` directory won't wedge those tags back into a fresh gateway on import.

## Testing
- `mvn compile -pl git-common,git-gateway -am` — clean.
- `mvn test -pl git-common,git-gateway -am` — passes (no pre-existing test infra for tag managers; not adding new infra in this minimal fix).
- Manual verification recommended: run an `exportConfig` against a gateway and confirm no `tags/System/` directory appears in the project repo.

Closes [TEC-3401](https://linear.app/whiskey-house-eandt/issue/TEC-3401/omit-system-tag-provider-from-git-tag-tracking)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * System provider is now protected from being exported or imported in tag configurations, preventing accidental modifications to critical system data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeyHouse/ignition-git-module/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->