### PR TITLE
fix(commissioning): honor commissioning_enforceBranch, stop silent YAML drops (TEC-3635)

### DIFF
--- a/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/utils/GitCommissioningUtils.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/commissioning/utils/GitCommissioningUtils.java
@@ -28,6 +28,8 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +38,34 @@ import static com.axone_io.ignition.git.managers.GitManager.*;
 
 public class GitCommissioningUtils {
     private final static LoggerEx logger = LoggerEx.newBuilder().build(GitCommissioningUtils.class);
+
+    /**
+     * Single source of truth for git.yaml key -> ProjectConfig field-name mapping.
+     * Any new YAML key must be added here AND backed by a real field on ProjectConfig.
+     * The companion unit test verifies every value resolves to a declared field.
+     */
+    public static final Map<String, String> YAML_KEY_TO_FIELD;
+    static {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("repo_uri", "repo_uri");
+        m.put("repo_branch", "repo_branch");
+        m.put("ignition_projectName", "ignition_projectName");
+        m.put("ignition_userName", "ignition_userName");
+        m.put("ignition_inheritable", "ignition_inheritable");
+        m.put("ignition_parentName", "ignition_parentName");
+        m.put("user_name", "user_name");
+        m.put("user_email", "user_email");
+        m.put("user_password", "user_password");
+        m.put("commissioning_importThemes", "commissioning_importThemes");
+        m.put("commissioning_importTags", "commissioning_importTags");
+        m.put("commissioning_importImages", "commissioning_importImages");
+        m.put("commissioning_enforceBranch", "commissioning_enforceBranch");
+        m.put("production_mode", "production_mode");
+        m.put("production_branch", "production_branch");
+        m.put("production_tagPattern", "production_tagPattern");
+        m.put("initDefaultBranch", "initDefaultBranch");
+        YAML_KEY_TO_FIELD = Collections.unmodifiableMap(m);
+    }
 
     public static GitCommissioningConfig config;
 
@@ -177,36 +207,48 @@ public class GitCommissioningUtils {
             String remoteName = GitManager.getRemoteName(git);
             String currentBranch = git.getRepository().getBranch();
             String configuredBranch = config.getRepoBranch();
+            boolean enforceBranch = config.isEnforceBranch();
+            boolean needsBranchSwitch = enforceBranch && !currentBranch.equals(configuredBranch);
 
-            // 1. Stash uncommitted changes
-            stashIfDirty(git, projectName);
-
-            // 2. Fetch from remote
+            // 1. Fetch from remote (non-destructive: only updates remote-tracking refs)
             logger.info("Fetching from remote '" + remoteName + "' for project '" + projectName + "'...");
             FetchCommand fetch = git.fetch().setRemote(remoteName);
             setAuthentication(fetch, projectName, config.getIgnitionUserName());
             fetch.call();
 
-            // 3. Switch branch if needed (and enforceBranch is enabled)
-            if (config.isEnforceBranch()) {
-                if (!currentBranch.equals(configuredBranch)) {
-                    logger.info("Switching project '" + projectName + "' from branch '" + currentBranch + "' to configured branch '" + configuredBranch + "'.");
-                    boolean localBranchExists = git.branchList().call().stream()
-                            .anyMatch(ref -> ref.getName().equals("refs/heads/" + configuredBranch));
-
-                    CheckoutCommand checkout = git.checkout().setName(configuredBranch);
-                    if (!localBranchExists) {
-                        checkout.setCreateBranch(true)
-                                .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
-                                .setStartPoint(remoteName + "/" + configuredBranch);
-                    }
-                    checkout.call();
-                }
-            } else {
-                logger.info("Skipping branch switch for project '" + projectName + "' because commissioning_enforceBranch is false. Staying on branch '" + currentBranch + "'.");
+            // 2. If enforceBranch is disabled, do NOT touch the working tree. Leave the
+            //    developer on their current branch with any uncommitted changes intact.
+            //    See TEC-3635: commissioning was force-switching developers off feature
+            //    branches and auto-stashing on every gateway restart.
+            if (!enforceBranch) {
+                logger.info("Skipping branch switch and stash for project '" + projectName
+                        + "' because commissioning_enforceBranch is false. Staying on branch '"
+                        + currentBranch + "' with working tree untouched.");
+                importProjectResources(config);
+                logger.info("Sync complete for project '" + projectName + "'.");
+                return;
             }
 
-            // 4. Pull latest
+            // 3. Stash uncommitted changes only when we are about to mutate the working tree
+            //    (i.e. switch branches). Avoids the noisy stash-pile reported in TEC-3635.
+            if (needsBranchSwitch) {
+                stashIfDirty(git, projectName);
+
+                logger.info("Switching project '" + projectName + "' from branch '" + currentBranch
+                        + "' to configured branch '" + configuredBranch + "'.");
+                boolean localBranchExists = git.branchList().call().stream()
+                        .anyMatch(ref -> ref.getName().equals("refs/heads/" + configuredBranch));
+
+                CheckoutCommand checkout = git.checkout().setName(configuredBranch);
+                if (!localBranchExists) {
+                    checkout.setCreateBranch(true)
+                            .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
+                            .setStartPoint(remoteName + "/" + configuredBranch);
+                }
+                checkout.call();
+            }
+
+            // 4. Pull latest on the (now) configured branch.
             String activeBranch = git.getRepository().getBranch();
             logger.info("Pulling latest changes for project '" + projectName + "' on branch '" + activeBranch + "'...");
             PullCommand pull = git.pull().setRemote(remoteName).setRemoteBranchName(activeBranch);
@@ -315,8 +357,15 @@ public class GitCommissioningUtils {
                                     logger.warn("Cannot set null value to primitive field: " + fieldName);
                                 }
                             }
-                        } catch (NoSuchFieldException | IllegalAccessException e) {
-                            logger.error("Error occurred in fetching YAML Git Config data ", e);
+                        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
+                            // Fail loudly: a misconfigured/unmapped YAML key would otherwise be
+                            // silently ignored and the project would run with stale defaults
+                            // (e.g. commissioning_enforceBranch never applied -> surprise branch
+                            // switches and auto-stashing on every gateway restart).
+                            logger.error("Error occurred in fetching YAML Git Config data for key '"
+                                    + entry.getKey() + "'", e);
+                            throw new RuntimeException(
+                                    "Invalid git.yaml: failed to apply key '" + entry.getKey() + "'", e);
                         }
 
                     }
@@ -349,35 +398,14 @@ public class GitCommissioningUtils {
         }
     }
 
-    private static String yamlKeyToFieldName(String yamlKey) {
-        // If the YAML key exactly matches the field name, just return it.
-        // This is a shortcut for cases where no conversion is necessary.
-        // Remove this line if all keys need conversion.
-        if (yamlKey.equals("repo_uri") || yamlKey.equals("repo_branch") ||
-                yamlKey.equals("ignition_projectName") || yamlKey.equals("ignition_userName") ||
-                yamlKey.equals("ignition_inheritable") || yamlKey.equals("ignition_parentName") ||
-                yamlKey.equals("user_name") || yamlKey.equals("user_email") ||
-                yamlKey.equals("user_password") || yamlKey.equals("commissioning_importThemes") ||
-                yamlKey.equals("commissioning_importTags") || yamlKey.equals("commissioning_importImages") ||
-                yamlKey.equals("commissioning_enforceBranch") ||
-                yamlKey.equals("production_mode") || yamlKey.equals("production_branch") ||
-                yamlKey.equals("production_tagPattern")) {
-            return yamlKey; // Your field names already match the YAML keys
+    public static String yamlKeyToFieldName(String yamlKey) {
+        String mapped = YAML_KEY_TO_FIELD.get(yamlKey);
+        if (mapped != null) {
+            return mapped;
         }
-
-        // Split the string at each underscore
-        String[] parts = yamlKey.split("_");
-        StringBuilder fieldName = new StringBuilder(parts[0]); // Keep the first part as is
-
-        // Convert the first letter of each subsequent part to uppercase
-        for (int i = 1; i < parts.length; i++) {
-            // Check if part is not empty to avoid StringIndexOutOfBoundsException
-            if (!parts[i].isEmpty()) {
-                fieldName.append(parts[i].substring(0, 1).toUpperCase()).append(parts[i].substring(1));
-            }
-        }
-
-        return fieldName.toString();
+        throw new IllegalArgumentException(
+                "Unknown git.yaml key '" + yamlKey + "'. "
+                        + "Add it to GitCommissioningUtils.YAML_KEY_TO_FIELD and ensure a matching field exists on ProjectConfig.");
     }
 }
 

--- a/git-gateway/src/test/java/com/axone_io/ignition/git/commissioning/GitCommissioningUtilsTest.java
+++ b/git-gateway/src/test/java/com/axone_io/ignition/git/commissioning/GitCommissioningUtilsTest.java
@@ -1,149 +1,49 @@
-//package com.axone_io.ignition.git.commissioning;
-//
-//import org.junit.Test;
-//import org.yaml.snakeyaml.LoaderOptions;
-//import org.yaml.snakeyaml.Yaml;
-//import org.yaml.snakeyaml.constructor.Constructor;
-//
-//import java.io.FileInputStream;
-//import java.io.FileNotFoundException;
-//import java.io.InputStream;
-//import java.nio.file.Path;
-//
-//import static com.axone_io.ignition.git.managers.GitManager.getDataFolderPath;
-//import static org.junit.Assert.*;
-//
-//public class GitCommissioningUtilsTest {
-//    @Test
-//    public void
-//    whenLoadYAMLDocumentWithTopLevelClass_thenLoadCorrectJavaObjectWithNestedObjects() throws FileNotFoundException {
-//
-//        Yaml yaml = new Yaml(new Constructor(ProjectConfigs.class, new LoaderOptions()));
-//        Path dataDir = getDataFolderPath();
-//        Path yamlConfigPath = dataDir.resolve("git.yaml"); // Assuming the YAML file is named git.yaml
-//        InputStream inputStream = new FileInputStream(yamlConfigPath.toFile());
-////        Yaml yaml = new Yaml(new Constructor(ProjectConfigs.class));
-////        InputStream inputStream = this.getClass()
-////                .getClassLoader()
-////                .getResourceAsStream("C:\\Users\\PatrickMannion\\IdeaProjects\\ignition-git-module\\git-gateway\\src\\test\\java\\com\\axone_io\\ignition\\git\\commissioning\\git.yaml");
-//        ProjectConfigs projectConfigs = yaml.load(inputStream);
-//
-//        assertNotNull(projectConfigs);
-//        assertNotNull(projectConfigs.getProjects());
-//        assertEquals(2, projectConfigs.getProjects()
-//                .size());
-//
-//        // Unit tests for first project in git.yaml
-//        assertNotNull(projectConfigs.getProjects()
-//                .get(0)
-//                .getRepo());
-//        assertEquals("https://github.com/WHK01/whk-distillery01-mes-ui.git", projectConfigs.getProjects()
-//                .get(0)
-//                .getRepo()
-//                .getUri());
-//        assertEquals("development", projectConfigs.getProjects()
-//                .get(0)
-//                .getRepo()
-//                .getBranch());
-//        assertEquals("WHK-MES", projectConfigs.getProjects()
-//                .get(0)
-//                .getIgnition()
-//                .getProjectName());
-//        assertEquals("admin", projectConfigs.getProjects()
-//                .get(0)
-//                .getIgnition()
-//                .getUserName());
-//        assertFalse(projectConfigs.getProjects()
-//                .get(0)
-//                .getIgnition()
-//                .isInheritable());
-//        assertEquals("Global", projectConfigs.getProjects()
-//                .get(0)
-//                .getIgnition()
-//                .getParentName());
-//        assertEquals("pmannion2", projectConfigs.getProjects()
-//                .get(0)
-//                .getUser()
-//                .getName());
-//        assertEquals("pmannion@whiskeyhouse.com", projectConfigs.getProjects()
-//                .get(0)
-//                .getUser()
-//                .getName());
-//        assertEquals("abc123", projectConfigs.getProjects()
-//                .get(0)
-//                .getUser()
-//                .getName());
-//        assertTrue(projectConfigs.getProjects()
-//                .get(0)
-//                .getCommissioning()
-//                .isImportThemes());
-//        assertTrue(projectConfigs.getProjects()
-//                .get(0)
-//                .getCommissioning()
-//                .isImportTags());
-//        assertTrue(projectConfigs.getProjects()
-//                .get(0)
-//                .getCommissioning()
-//                .isImportImages());
-//        assertEquals("main",projectConfigs.getProjects()
-//                .get(0)
-//                .getInitDefaultBranch());
-//
-//
-//        // Unit tests for second project in git.yaml
-//        assertNotNull(projectConfigs.getProjects()
-//                .get(1)
-//                .getRepo());
-//        assertEquals("https://github.com/WHK01/whk-distillery01-ignition-global.git", projectConfigs.getProjects()
-//                .get(1)
-//                .getRepo()
-//                .getUri());
-//        assertEquals("development", projectConfigs.getProjects()
-//                .get(1)
-//                .getRepo()
-//                .getBranch());
-//        assertEquals("WHK-MES", projectConfigs.getProjects()
-//                .get(1)
-//                .getIgnition()
-//                .getProjectName());
-//        assertEquals("admin", projectConfigs.getProjects()
-//                .get(1)
-//                .getIgnition()
-//                .getUserName());
-//        assertFalse(projectConfigs.getProjects()
-//                .get(1)
-//                .getIgnition()
-//                .isInheritable());
-//        assertEquals("Global", projectConfigs.getProjects()
-//                .get(1)
-//                .getIgnition()
-//                .getParentName());
-//        assertEquals("pmannion2", projectConfigs.getProjects()
-//                .get(1)
-//                .getUser()
-//                .getName());
-//        assertEquals("pmannion@whiskeyhouse.com", projectConfigs.getProjects()
-//                .get(1)
-//                .getUser()
-//                .getName());
-//        assertEquals("abc123", projectConfigs.getProjects()
-//                .get(1)
-//                .getUser()
-//                .getName());
-//        assertTrue(projectConfigs.getProjects()
-//                .get(1)
-//                .getCommissioning()
-//                .isImportThemes());
-//        assertTrue(projectConfigs.getProjects()
-//                .get(1)
-//                .getCommissioning()
-//                .isImportTags());
-//        assertTrue(projectConfigs.getProjects()
-//                .get(1)
-//                .getCommissioning()
-//                .isImportImages());
-//        assertEquals("main",projectConfigs.getProjects()
-//                .get(1)
-//                .getInitDefaultBranch());
-//    }
-//}
+package com.axone_io.ignition.git.commissioning;
+
+import com.axone_io.ignition.git.commissioning.utils.GitCommissioningUtils;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Locks the YAML key -> ProjectConfig field mapping used by commissioning.
+ *
+ * The original bug (TEC-3635) was that 'commissioning_enforceBranch' silently
+ * mapped to a non-existent 'commissioningEnforceBranch' field, swallowing a
+ * NoSuchFieldException and forcing every gateway restart to switch developers
+ * off feature branches. These tests prevent that drift from recurring.
+ */
+public class GitCommissioningUtilsTest {
+
+    @Test
+    public void everyMappedYamlKeyResolvesToARealProjectConfigField() throws NoSuchFieldException {
+        for (Map.Entry<String, String> entry : GitCommissioningUtils.YAML_KEY_TO_FIELD.entrySet()) {
+            String yamlKey = entry.getKey();
+            String fieldName = entry.getValue();
+            Field field = ProjectConfig.class.getDeclaredField(fieldName);
+            assertNotNull("Field resolution returned null for " + yamlKey, field);
+        }
+    }
+
+    @Test
+    public void enforceBranchKeyMapsToActualField() throws NoSuchFieldException {
+        String fieldName = GitCommissioningUtils.yamlKeyToFieldName("commissioning_enforceBranch");
+        Field field = ProjectConfig.class.getDeclaredField(fieldName);
+        assertEquals(Boolean.class, field.getType());
+    }
+
+    @Test
+    public void unknownYamlKeyFailsLoudly() {
+        try {
+            GitCommissioningUtils.yamlKeyToFieldName("this_key_does_not_exist");
+            fail("Expected IllegalArgumentException for unknown YAML key");
+        } catch (IllegalArgumentException expected) {
+            // ok: misconfigured keys must surface, not be silently dropped
+        }
+    }
+}


### PR DESCRIPTION
Assignee: @TheThoughtagen ([pmannion](https://linear.app/whiskey-house-eandt/profiles/pmannion))

## Summary

Fixes [TEC-3635](https://linear.app/whiskey-house-eandt/issue/TEC-3635/git-module-commissioning-enforcebranch-silently-ignored). The Git module's commissioning routine was force-switching every existing project from the developer's current branch back to the configured `repo_branch` on every gateway startup, auto-stashing any uncommitted work first. The `commissioning_enforceBranch: false` setting was being silently dropped (originally a `NoSuchFieldException` on the camel-cased field name in the deployed jar), so enforcement could not be turned off.

## Changes

- **Centralized YAML→field mapping** (`YAML_KEY_TO_FIELD` map) — single source of truth, eliminating the brittle whitelist + camelCase heuristic that originally let `commissioning_enforceBranch` map to a non-existent field.
- **Fail loudly on misconfig** — `parseYaml` now throws a `RuntimeException` for any YAML key that cannot be applied, instead of logging at error level and continuing with stale defaults.
- **Honor `enforceBranch=false`** — `syncExistingProject` now skips both the auto-stash and the branch checkout entirely when `enforceBranch=false`. Only a non-destructive `fetch` runs; the developer's working tree (branch + uncommitted edits) is left completely untouched.
- **Stash only when needed** — even with `enforceBranch=true`, the stash now only runs when we're about to actually switch branches.
- **Lock-down unit test** (`GitCommissioningUtilsTest`) — asserts every YAML key in the mapping resolves to a real declared field on `ProjectConfig`, plus a positive `enforceBranch` test and a negative "unknown key fails loudly" test. Prevents future drift (e.g. when adding new `production_*` keys).

## Test plan
- [x] `mvn -pl git-gateway -am test` — 60/60 pass (including the 3 new tests)
- [x] Manual review of `syncExistingProject` ordering: fetch → (early return if !enforceBranch) → stash-if-needed → checkout → pull → import
- [ ] Restart gateway in dev stack with `commissioning_enforceBranch: false` on a feature branch with uncommitted edits → verify branch + working tree untouched
- [ ] Verify with `commissioning_enforceBranch: true` that the previous branch-switch behavior still works
- [ ] Verify a malformed YAML key surfaces a loud `RuntimeException` in the gateway log instead of silently committing stale defaults

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced configuration validation with more specific error messages when invalid settings are encountered.
  * Refined branch synchronization flow to properly respect branch enforcement settings, reducing unnecessary operations when enforcement is disabled.

* **Tests**
  * Added comprehensive test coverage for configuration mapping validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeyHouse/ignition-git-module/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->