### PR TITLE
fix(tags): skip hidden/dot entries during tag import (TEC-3647)

### DIFF
--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
@@ -168,6 +168,10 @@ public class GitTagGroupManager {
         try (DirectoryStream<Path> providerDirs = Files.newDirectoryStream(tagsDir, Files::isDirectory)) {
             for (Path providerDir : providerDirs) {
                 String providerName = providerDir.getFileName().toString();
+                // Skip hidden/dot dirs (.omc, .claude, .git, etc.) that may sit alongside provider dirs.
+                if (providerName.startsWith(".")) {
+                    continue;
+                }
                 Path groupsFile = providerDir.resolve(TAG_GROUPS_FILENAME);
 
                 if (!Files.exists(groupsFile)) {

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
@@ -73,6 +73,19 @@ public class GitTagManager {
     private static final String FS_RESERVED_CHARS = "<>:\"/\\|?*";
 
     /**
+     * Returns {@code true} for filesystem entries whose names start with {@code "."} — agent
+     * state directories like {@code .omc}, {@code .claude}, {@code .cursor}, VCS metadata
+     * ({@code .git}), and the internal config files ({@code .tag-config.json},
+     * {@code .tag-groups.json}). Ignition rejects tag names starting with {@code "."} as
+     * invalid ({@code Error_Configuration("The name '.omc' is not a valid tag name")}), so
+     * filtering them out during import prevents a single stray dot-folder in the working tree
+     * from derailing the rest of the provider's tag import.
+     */
+    static boolean isHiddenEntry(String name) {
+        return name != null && name.startsWith(".");
+    }
+
+    /**
      * Encodes a tag name so it is safe to use as a filesystem path segment on any OS.
      * Reserved characters, control characters, and the percent sign itself are
      * replaced with {@code %XX} hex escapes. Names with only safe characters are
@@ -162,7 +175,7 @@ public class GitTagManager {
         if (files == null) return;
 
         for (File file : files) {
-            if (!file.isFile() || !file.getName().endsWith(".json") || file.getName().equals(TAG_CONFIG_FILENAME)) {
+            if (!file.isFile() || !file.getName().endsWith(".json") || isHiddenEntry(file.getName())) {
                 continue;
             }
             String providerName = FilenameUtils.removeExtension(file.getName());
@@ -196,6 +209,10 @@ public class GitTagManager {
         try (DirectoryStream<Path> providerDirs = Files.newDirectoryStream(tagsDir, Files::isDirectory)) {
             for (Path providerDir : providerDirs) {
                 String providerName = providerDir.getFileName().toString();
+                if (isHiddenEntry(providerName)) {
+                    logger.debug("Skipping hidden/dot directory under tags/: " + providerName);
+                    continue;
+                }
                 if (TagExportConfig.SYSTEM_PROVIDER_NAME.equals(providerName)) {
                     logger.debug("Skipping individual-file import for built-in System provider.");
                     continue;
@@ -380,6 +397,7 @@ public class GitTagManager {
         if (files == null) return;
 
         for (File file : files) {
+            if (isHiddenEntry(file.getName())) continue;
             if (file.isDirectory()) {
                 String newPrefix = pathPrefix.isEmpty() ? file.getName() : pathPrefix + "/" + file.getName();
                 collectUdtFiles(file.toPath(), udtArray, newPrefix);
@@ -410,7 +428,7 @@ public class GitTagManager {
      * @param skipTypesDir  if {@code true}, skips the {@code _types_/} directory
      * @return a JsonObject where keys are tag/folder names and values are their JSON definitions
      */
-    private static JsonObject readTagsFromDirectory(Path dir, boolean skipTypesDir) {
+    static JsonObject readTagsFromDirectory(Path dir, boolean skipTypesDir) {
         JsonObject tags = new JsonObject();
         File[] entries = dir.toFile().listFiles();
         if (entries == null) return tags;
@@ -418,10 +436,11 @@ public class GitTagManager {
         for (File entry : entries) {
             String fsName = entry.getName();
 
-            // Skip config and tag-groups files (tag groups are imported separately).
-            // These constants contain only safe characters, so compare against the raw filesystem name.
-            if (fsName.equals(TAG_CONFIG_FILENAME)) continue;
-            if (fsName.equals(GitTagGroupManager.TAG_GROUPS_FILENAME)) continue;
+            // Skip hidden/dot entries — covers .tag-config.json, .tag-groups.json, and any
+            // agent-state directories like .omc/ or .claude/ that may be present in the
+            // working tree. Ignition rejects tag names starting with "." as invalid, so a
+            // single stray dot-folder would otherwise abort the entire provider import.
+            if (isHiddenEntry(fsName)) continue;
 
             // Optionally skip _types_ directory (handled separately for UDT ordering)
             if (skipTypesDir && fsName.equals(TYPES_DIR_NAME)) continue;

--- a/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagManagerTest.java
+++ b/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagManagerTest.java
@@ -1,9 +1,17 @@
 package com.axone_io.ignition.git.managers;
 
+import com.inductiveautomation.ignition.common.gson.JsonObject;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class GitTagManagerTest {
 
@@ -65,5 +73,78 @@ public class GitTagManagerTest {
     public void decodeFsName_handlesNullAndEmpty() {
         assertNull(GitTagManager.decodeFsName(null));
         assertEquals("", GitTagManager.decodeFsName(""));
+    }
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void isHiddenEntry_flagsDotPrefixedNames() {
+        // Agent-state dirs that have poisoned imports in production (TEC-3647)
+        assertTrue(GitTagManager.isHiddenEntry(".omc"));
+        assertTrue(GitTagManager.isHiddenEntry(".claude"));
+        assertTrue(GitTagManager.isHiddenEntry(".git"));
+        // Internal config files we already skipped by exact name
+        assertTrue(GitTagManager.isHiddenEntry(".tag-config.json"));
+        assertTrue(GitTagManager.isHiddenEntry(".tag-groups.json"));
+    }
+
+    @Test
+    public void isHiddenEntry_leavesNormalNamesAlone() {
+        assertFalse(GitTagManager.isHiddenEntry("WHK01"));
+        assertFalse(GitTagManager.isHiddenEntry("Cooker01"));
+        assertFalse(GitTagManager.isHiddenEntry("_types_"));
+        assertFalse(GitTagManager.isHiddenEntry("LoadRecipeTrigger.json"));
+        assertFalse(GitTagManager.isHiddenEntry(""));
+        assertFalse(GitTagManager.isHiddenEntry(null));
+    }
+
+    @Test
+    public void readTagsFromDirectory_skipsDotFoldersAndDotFiles() throws Exception {
+        // Reproduces the TEC-3647 scenario: a stray .omc/ agent-state folder lives
+        // inside an authored tag-folder tree. The importer must ignore it (and any
+        // .json file with a leading dot) instead of producing an invalid '.omc' tag.
+        File providerRoot = tempFolder.newFolder("WHK01");
+
+        File cooker = new File(providerRoot, "Cooker01");
+        assertTrue(cooker.mkdirs());
+
+        File realTag = new File(cooker, "LoadRecipeTrigger.json");
+        Files.writeString(realTag.toPath(),
+                "{\"tagType\":\"AtomicTag\",\"valueSource\":\"memory\",\"dataType\":\"Boolean\"}");
+
+        // Agent-state folder that previously caused Error_Configuration on import.
+        File omcDir = new File(cooker, ".omc");
+        assertTrue(omcDir.mkdirs());
+        Files.writeString(new File(omcDir, "state.json").toPath(), "{\"junk\":true}");
+
+        // Hidden file directly under the provider root — also must be ignored.
+        Files.writeString(new File(providerRoot, ".tag-config.json").toPath(), "{}");
+
+        JsonObject result = GitTagManager.readTagsFromDirectory(providerRoot.toPath(), true);
+
+        // Cooker01 folder is kept and contains the real tag.
+        assertTrue("expected Cooker01 folder in result", result.has("Cooker01"));
+        JsonObject cookerJson = result.getAsJsonObject("Cooker01");
+        assertEquals("Folder", cookerJson.get("tagType").getAsString());
+        assertTrue("expected child 'tags' array under Cooker01", cookerJson.has("tags"));
+
+        // No '.omc' anywhere — neither at the root nor under Cooker01.
+        assertFalse(".omc must not appear at provider root", result.has(".omc"));
+        for (var entry : result.entrySet()) {
+            assertFalse(".omc must not appear as a sibling folder",
+                    entry.getKey().equals(".omc"));
+        }
+
+        var cookerChildren = cookerJson.getAsJsonArray("tags");
+        boolean sawOmc = false;
+        boolean sawRealTag = false;
+        for (var child : cookerChildren) {
+            String childName = child.getAsJsonObject().get("name").getAsString();
+            if (".omc".equals(childName)) sawOmc = true;
+            if ("LoadRecipeTrigger".equals(childName)) sawRealTag = true;
+        }
+        assertFalse(".omc must not appear under Cooker01", sawOmc);
+        assertTrue("LoadRecipeTrigger.json should still be imported", sawRealTag);
     }
 }


### PR DESCRIPTION
Assignee: @TheThoughtagen ([pmannion](https://linear.app/whiskey-house-eandt/profiles/pmannion))

## Summary

Fixes the `.omc`/invalid-tag-name failure mode from [TEC-3647](https://linear.app/whiskey-house-eandt/issue/TEC-3647/whk-global-dev-gateway-loses-whk01-tags-and-force-switches-off-active).

When a working tree contains an agent-state directory like `tags/WHK01/.omc/` (or `.claude/`, `.cursor/`, etc.), the tag import treated it as a tag folder and Ignition aborted the WHK01 provider import with:

> `Error_Configuration("The name '.omc' is not a valid tag name")`

This PR adds an `isHiddenEntry` filter (skip any filesystem entry whose name starts with `.`) at every directory-scan site in the import path:

- `GitTagManager.importFromIndividualFiles` — provider dirs under `tags/`
- `GitTagManager.importFromLegacyFiles` — legacy single-file `.json` scan
- `GitTagManager.readTagsFromDirectory` — recursive folder tree
- `GitTagManager.collectUdtFiles` — recursive UDT tree
- `GitTagGroupManager.importTagGroups` — provider dirs under `tags/`

The existing exact-name skips for `.tag-config.json` and `.tag-groups.json` are subsumed by the new rule. Ignition itself rejects tag names starting with `.` as invalid, so no real authored tag is filtered out.

### Scope note vs. TEC-3647 acceptance criteria

Three issues compound in TEC-3647. Only AC #3 lives in this repo:

| AC | Where | Status |
|---|---|---|
| #1 – no force-switch off active branch on restart | `commissioning_enforceBranch` honor fix is here (commit a81754f, prior PR); final `commissioning_enforceBranch: false` toggle lives in `whk-environment-orchestration/gw-init/git.yaml` | Code-side done; config-side handled in env orchestration |
| #2 – stale `tags/WHK01.json` cleanup in secondary repos, `importTags: false` on non-WHK-Global projects | `whk-ignition-scada`, `whk-ignition-scheduling`, `whk-ignition-reporting`, `whk-environment-orchestration` | Out of scope here |
| #3 – no `.omc`/invalid-tag-name errors in `GitTagManager` import results | This repo | **Fixed in this PR** |

## Test plan

- [x] New `GitTagManagerTest.isHiddenEntry_*` cases assert the filter accepts normal names (`WHK01`, `_types_`, `LoadRecipeTrigger.json`) and rejects dot-prefixed ones (`.omc`, `.claude`, `.git`).
- [x] New `readTagsFromDirectory_skipsDotFoldersAndDotFiles` reproduces the TEC-3647 scenario: builds a temp `WHK01/Cooker01/` tree containing both a real `LoadRecipeTrigger.json` and an `.omc/` agent-state folder, then asserts (a) the real tag survives, (b) `.omc` does not appear at the root or under `Cooker01`, (c) the `.tag-config.json` at the provider root is also ignored.
- [x] `mvn -pl git-gateway test -Dtest=GitTagManagerTest` — 10/10 pass.
- [ ] Manual: build the `.modl`, hot-deploy to `whk-development-gw`, restart gateway, confirm `GitTagManager` log shows `Importing tags for project 'WHK-Global'` followed by a clean `Import result for provider 'WHK01': ...` with **no** `Error_Configuration("The name '.omc' is not a valid tag name")` line.
- [ ] Manual: confirm `[WHK01].../Cooker01/MES/LoadRecipeTrigger` resolves (not `Bad_NotFound`) after the full TEC-3647 stopgap stack is in place (this PR + the env-orchestration `enforceBranch:false` + `importTags:false` changes already merged).

### Pre-existing test failures (not caused by this PR)

`ProductionModeManagerTest` fails with `NoClassDefFound com/axone_io/ignition/git/dto/ProductionModeConfig` (18 errors). Verified these fail identically on `main` tip (a81754f) before this branch's changes — pre-existing classpath wiring issue, tracked separately.

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden files and directories (starting with `.`) are now properly skipped during tag import, export, and UDT discovery operations, preventing unrelated entries from interfering with tag processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->