### PR TITLE
Production mode: warn at save time, auto-commit and auto-push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,9 +149,10 @@ git merge --abort  # If in merge state
 Production mode protects production gateways from accidental Git operations. When enabled:
 
 - **Pull** requires a safety checklist (4 checkboxes) + validates repo state, branch, and tags
-- **Push** warns when targeting the production branch
+- **Saving** shows the safety checklist (the save is what changes the gateway), then auto-opens the commit dialog
+- **Commits** auto-push to remote; on the production branch they trigger the automated **hotfix workflow** (branch → commit → push → create PR → merge locally → cleanup)
+- **Push** has no Designer-side warning (outbound only; the gateway still blocks pushes from unsafe repo states)
 - **Branch switching** is blocked entirely
-- **Commits** on the production branch trigger the automated **hotfix workflow** (branch → commit → push → create PR → merge locally → cleanup)
 - **PRODUCTION** badge shown in Designer status bar
 
 Configured via `git.yaml`:

--- a/docs/production-mode.md
+++ b/docs/production-mode.md
@@ -113,16 +113,19 @@ flowchart TD
     VALIDATE -->|All pass| EXEC_PULL[Execute pull]
     VALIDATE -->|Any fail| BLOCK_VALIDATION[BLOCKED<br/>with reason]
 
-    TYPE -->|Push| PROD_CHECK_PUSH{Production mode?}
-    PROD_CHECK_PUSH -->|No| NORMAL_PUSH[Normal push]
-    PROD_CHECK_PUSH -->|Yes| PUSH_TARGET{Pushing to<br/>production branch?}
-    PUSH_TARGET -->|No| EXEC_PUSH[Execute push]
-    PUSH_TARGET -->|Yes| PUSH_WARN[Warning + confirmation<br/>required]
-    PUSH_WARN --> EXEC_PUSH
+    TYPE -->|Push| EXEC_PUSH[Execute push<br/>no Designer warning -- push is outbound;<br/>gateway still blocks unsafe repo states]
+
+    TYPE -->|Save Ctrl+S| PROD_CHECK_SAVE{Production mode?}
+    PROD_CHECK_SAVE -->|No| NORMAL_SAVE[Normal save]
+    PROD_CHECK_SAVE -->|Yes| SAVE_WARN[ProductionModePopup<br/>4-item safety checklist]
+    SAVE_WARN --> COMMIT_FLOW[Commit dialog auto-opens<br/>hotfix workflow on production branch]
 
     TYPE -->|Commit| PROD_CHECK_COMMIT{Production mode +<br/>on production branch?}
     PROD_CHECK_COMMIT -->|No| NORMAL_COMMIT[Normal commit]
     PROD_CHECK_COMMIT -->|Yes| HOTFIX[Hotfix Workflow]
+    NORMAL_COMMIT --> AUTO_PUSH{Production mode?}
+    AUTO_PUSH -->|Yes| EXEC_PUSH
+    AUTO_PUSH -->|No| COMMIT_DONE[Done]
 
     TYPE -->|Branch Switch| PROD_CHECK_BRANCH{Production mode?}
     PROD_CHECK_BRANCH -->|No| NORMAL_BRANCH[Normal branch switch]
@@ -132,7 +135,7 @@ flowchart TD
     style BLOCK_VALIDATION fill:#FFCDD2
     style BLOCK_BRANCH fill:#FFCDD2
     style HOTFIX fill:#C8E6C9
-    style PUSH_WARN fill:#FFF9C4
+    style SAVE_WARN fill:#FFF9C4
 ```
 
 ### Repository Safety Checks
@@ -183,8 +186,8 @@ sequenceDiagram
     participant GH as GitHub
 
     E->>D: Makes fix, saves (Ctrl+S)
-    D->>E: "Commit changes?" prompt
-    E->>D: Clicks "Yes"
+    D->>E: Production warning (safety checklist)
+    E->>D: Checks all items, clicks "Proceed with Caution"
 
     D->>G: getProductionModeConfig()
     G-->>D: config (productionMode=true, branch=main)
@@ -228,8 +231,8 @@ sequenceDiagram
 
 1. **Engineer makes a fix** in the Ignition Designer (edits a script, modifies a view, etc.)
 2. **Saves the project** (Ctrl+S)
-3. **Module prompts:** "You've saved changes on a production gateway. Would you like to commit and track these changes?"
-4. **Engineer clicks Yes** -- the module detects the hotfix scenario (production mode + on production branch)
+3. **Module shows the production warning** -- the 4-item safety checklist (`ProductionModePopup`), since the save is what changed the gateway
+4. **Engineer confirms** -- the commit dialog opens automatically and the module detects the hotfix scenario (production mode + on production branch)
 5. **Hotfix Commit Dialog appears** -- the engineer provides:
    - A short **hotfix description** (used in branch name and PR title)
    - A **commit message** explaining the fix

--- a/git-designer/src/main/java/com/axone_io/ignition/git/DesignerHook.java
+++ b/git-designer/src/main/java/com/axone_io/ignition/git/DesignerHook.java
@@ -292,16 +292,50 @@ public class DesignerHook extends AbstractDesignerModuleHook {
         // production warning lives (push is outbound and not gated). Proceeding flows straight
         // into the commit dialog \u2014 hotfix workflow on the production branch \u2014 and commits in
         // production mode auto-push, keeping the remote in sync with the gateway.
-        if (cachedProductionConfig != null && cachedProductionConfig.isProductionMode()) {
-            SwingUtilities.invokeLater(() -> {
-                new ProductionModePopup(context.getFrame(), cachedProductionConfig, "Save to Production Gateway") {
-                    @Override
-                    public void onProceed() {
-                        GitActionManager.showCommitWithHotfixDetection(projectName, userName);
-                    }
-                };
-            });
+        ProductionModeConfig config = cachedProductionConfig;
+        if (config != null) {
+            showSaveWarningIfProduction(config);
+            return;
         }
+
+        // The cache is null after invalidation (pull, branch switch, hotfix) until the periodic
+        // refresh fires \u2014 re-fetch now rather than letting a save slip through ungated.
+        SwingWorker<ProductionModeConfig, Void> worker = new SwingWorker<ProductionModeConfig, Void>() {
+            @Override
+            protected ProductionModeConfig doInBackground() throws Exception {
+                return rpc.getProductionModeConfig(projectName);
+            }
+
+            @Override
+            protected void done() {
+                ProductionModeConfig fetched;
+                try {
+                    fetched = get();
+                    cachedProductionConfig = fetched;
+                } catch (Exception e) {
+                    // Can't verify \u2014 treat the gateway as production rather than failing open.
+                    logger.warn("Unable to verify production mode after save; showing warning conservatively", e);
+                    fetched = new ProductionModeConfig(true, null, null);
+                    fetched.setWarningMessage("Unable to verify production mode for this gateway: " + e.getMessage());
+                }
+                showSaveWarningIfProduction(fetched);
+            }
+        };
+        worker.execute();
+    }
+
+    private void showSaveWarningIfProduction(ProductionModeConfig config) {
+        if (config == null || !config.isProductionMode()) {
+            return;
+        }
+        SwingUtilities.invokeLater(() -> {
+            new ProductionModePopup(context.getFrame(), config, "Save to Production Gateway") {
+                @Override
+                public void onProceed() {
+                    GitActionManager.showCommitWithHotfixDetection(projectName, userName);
+                }
+            };
+        });
     }
 
     @Override

--- a/git-designer/src/main/java/com/axone_io/ignition/git/DesignerHook.java
+++ b/git-designer/src/main/java/com/axone_io/ignition/git/DesignerHook.java
@@ -288,19 +288,18 @@ public class DesignerHook extends AbstractDesignerModuleHook {
     public void notifyProjectSaveDone() {
         super.notifyProjectSaveDone();
 
-        // In production mode, prompt the engineer to commit after saving
+        // Saving is the moment the production gateway actually changes, so this is where the
+        // production warning lives (push is outbound and not gated). Proceeding flows straight
+        // into the commit dialog \u2014 hotfix workflow on the production branch \u2014 and commits in
+        // production mode auto-push, keeping the remote in sync with the gateway.
         if (cachedProductionConfig != null && cachedProductionConfig.isProductionMode()) {
             SwingUtilities.invokeLater(() -> {
-                int result = JOptionPane.showConfirmDialog(
-                    context.getFrame(),
-                    "You've saved changes on a production gateway.\nWould you like to commit and track these changes?",
-                    "Production Mode \u2014 Commit Changes?",
-                    JOptionPane.YES_NO_OPTION,
-                    JOptionPane.QUESTION_MESSAGE
-                );
-                if (result == JOptionPane.YES_OPTION) {
-                    GitActionManager.showCommitWithHotfixDetection(projectName, userName);
-                }
+                new ProductionModePopup(context.getFrame(), cachedProductionConfig, "Save to Production Gateway") {
+                    @Override
+                    public void onProceed() {
+                        GitActionManager.showCommitWithHotfixDetection(projectName, userName);
+                    }
+                };
             });
         }
     }

--- a/git-designer/src/main/java/com/axone_io/ignition/git/actions/GitBaseAction.java
+++ b/git-designer/src/main/java/com/axone_io/ignition/git/actions/GitBaseAction.java
@@ -16,7 +16,7 @@ import static com.axone_io.ignition.git.DesignerHook.*;
 import static com.axone_io.ignition.git.managers.GitActionManager.showCommitPopup;
 import static com.axone_io.ignition.git.managers.GitActionManager.showCommitWithHotfixDetection;
 import static com.axone_io.ignition.git.managers.GitActionManager.showPullPopup;
-import static com.axone_io.ignition.git.managers.GitActionManager.showPushWithProductionCheck;
+import static com.axone_io.ignition.git.managers.GitActionManager.pushCurrentBranch;
 import static com.axone_io.ignition.git.managers.GitActionManager.showHistoryViewer;
 import static com.axone_io.ignition.git.managers.GitActionManager.showBranchPopup;
 import static com.axone_io.ignition.git.managers.GitActionManager.showConfirmPopup;
@@ -102,7 +102,25 @@ public class GitBaseAction extends BaseAction {
 
         try {
             rpc.commit(projectName, userName, changes.toArray(new String[0]), commitMessage);
-            SwingUtilities.invokeLater(new Thread(() -> showConfirmPopup(message, messageType)));
+
+            // In production mode the remote should always mirror the gateway, so push
+            // immediately instead of leaving it as a separate manual step. Commits on the
+            // production branch never reach here — hotfix detection routes them to the
+            // hotfix pipeline, which pushes on its own.
+            try {
+                if (rpc.getProductionModeConfig(projectName).isProductionMode()) {
+                    rpc.push(projectName, userName);
+                    message += "\n" + BundleUtil.get().getStringLenient(GitActionType.PUSH.baseBundleKey + ".ConfirmMessage");
+                }
+            } catch (Exception pushEx) {
+                logger.error("Auto-push after commit failed", pushEx);
+                message += "\nCommit succeeded, but automatic push failed:\n" + pushEx.getMessage();
+                messageType = JOptionPane.WARNING_MESSAGE;
+            }
+
+            final String finalMessage = message;
+            final int finalMessageType = messageType;
+            SwingUtilities.invokeLater(new Thread(() -> showConfirmPopup(finalMessage, finalMessageType)));
         } catch (Exception ex) {
             ErrorUtil.showError(ex);
         }
@@ -175,7 +193,7 @@ public class GitBaseAction extends BaseAction {
                     break;
                 case PUSH:
                     confirmPopup = Boolean.FALSE;
-                    showPushWithProductionCheck(projectName, userName);
+                    pushCurrentBranch(projectName, userName);
                     break;
                 case COMMIT:
                     confirmPopup = Boolean.FALSE;

--- a/git-designer/src/main/java/com/axone_io/ignition/git/managers/GitActionManager.java
+++ b/git-designer/src/main/java/com/axone_io/ignition/git/managers/GitActionManager.java
@@ -342,42 +342,14 @@ public class GitActionManager {
         DesignerHook.invalidateProductionConfigCache();
     }
 
-    public static void showPushWithProductionCheck(String projectName, String userName) {
-        SwingWorker<ProductionModeConfig, Void> worker = new SwingWorker<ProductionModeConfig, Void>() {
-            @Override
-            protected ProductionModeConfig doInBackground() throws Exception {
-                return rpc.getProductionModeConfig(projectName);
-            }
-
-            @Override
-            protected void done() {
-                try {
-                    ProductionModeConfig prodConfig = get();
-
-                    if (prodConfig.isProductionMode()) {
-                        logger.info("Production mode is active for project: " + projectName + " — showing push confirmation");
-
-                        new ProductionModePopup(context.getFrame(), prodConfig, "Push to Remote") {
-                            @Override
-                            public void onProceed() {
-                                executePush(projectName, userName);
-                            }
-                        };
-                    } else {
-                        executePush(projectName, userName);
-                    }
-                } catch (Exception e) {
-                    logger.error("Error checking production mode for push", e);
-                    JOptionPane.showMessageDialog(
-                        context.getFrame(),
-                        "Unable to verify production mode for this project. Push was blocked.\n\n" + e.getMessage(),
-                        "Production Mode Check Failed",
-                        JOptionPane.ERROR_MESSAGE
-                    );
-                }
-            }
-        };
-        worker.execute();
+    /**
+     * Push the current branch to remote. Push is outbound and does not modify this gateway,
+     * so there is no Designer-side production warning here — the warning happens at save time
+     * (see DesignerHook.notifyProjectSaveDone), and the gateway still hard-blocks pushes from
+     * unsafe repository states.
+     */
+    public static void pushCurrentBranch(String projectName, String userName) {
+        executePush(projectName, userName);
     }
 
     private static void executePush(String projectName, String userName) {


### PR DESCRIPTION
## Summary

The production-mode safety checklist used to appear on **push** — but push is outbound and doesn't change the gateway. By the time you push, the gateway was already modified when you saved in the Designer. This PR moves the warning to the actual mutation point and automates the rest:

- **Save** (`DesignerHook.notifyProjectSaveDone`) now shows the full `ProductionModePopup` safety checklist (always, in production mode), then auto-opens the commit dialog — hotfix workflow when on the production branch — replacing the old soft "Would you like to commit?" prompt
- **Commits auto-push** in production mode so the remote always mirrors the gateway; if the push fails, the user sees "commit succeeded, push failed" rather than a silent gap
- **Push** no longer shows any Designer-side dialog (`pushCurrentBranch`, renamed from `showPushWithProductionCheck`); the gateway-side `validatePush` hard block for unsafe repo states is unchanged
- Updated `docs/production-mode.md` flowcharts/sequence diagram and CLAUDE.md to match

## Test plan

- [x] `mvn -pl git-designer -am compile` passes
- [ ] Hot-deploy to a production-mode gateway: save in Designer → checklist appears → proceed → commit dialog opens → commit auto-pushes
- [ ] On the production branch: save → checklist → hotfix dialog → pipeline runs (pushes hotfix branch + PR as before)
- [ ] Toolbar push: no dialog, pushes current branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saving in Production Mode now shows a 4-item safety checklist then opens the commit dialog.

* **Changes**
  * Commits on the production branch auto-push and trigger the hotfix workflow.
  * Push operations proceed without a Designer-side warning (safety enforced server-side).
  * Hotfix flow updated to use the checklist + “Proceed with Caution” confirmation.
  * Branch switching remains blocked in Production Mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->