### PR TITLE
fix(tags): non-destructive tag-group export + reconcile unknown groups on import

### DIFF
--- a/git-client/src/main/java/com/axone_io/ignition/git/ClientScriptModule.java
+++ b/git-client/src/main/java/com/axone_io/ignition/git/ClientScriptModule.java
@@ -185,4 +185,9 @@ public class ClientScriptModule extends AbstractScriptModule {
     protected HotfixResult getLastHotfixStatusImpl(String projectName) throws Exception {
         return rpc.getLastHotfixStatus(projectName);
     }
+
+    @Override
+    protected String diagnoseTagGroupsImpl() throws Exception {
+        return rpc.diagnoseTagGroups();
+    }
 }

--- a/git-common/src/main/java/com/axone_io/ignition/git/AbstractScriptModule.java
+++ b/git-common/src/main/java/com/axone_io/ignition/git/AbstractScriptModule.java
@@ -217,6 +217,11 @@ public abstract class AbstractScriptModule implements GitScriptInterface {
         return getLastHotfixStatusImpl(projectName);
     }
 
+    @Override
+    public String diagnoseTagGroups() throws Exception {
+        return diagnoseTagGroupsImpl();
+    }
+
     protected abstract boolean pullImpl(String projectName, String userName, boolean importTags, boolean importTheme,
                                         boolean importImages) throws Exception;
     protected abstract boolean pushImpl(String projectName, String userName) throws Exception;
@@ -253,5 +258,6 @@ public abstract class AbstractScriptModule implements GitScriptInterface {
                                                       String[] changes) throws Exception;
     protected abstract HotfixResult getHotfixProgressImpl(String projectName) throws Exception;
     protected abstract HotfixResult getLastHotfixStatusImpl(String projectName) throws Exception;
+    protected abstract String diagnoseTagGroupsImpl() throws Exception;
 
 }

--- a/git-common/src/main/java/com/axone_io/ignition/git/GitScriptInterface.java
+++ b/git-common/src/main/java/com/axone_io/ignition/git/GitScriptInterface.java
@@ -64,4 +64,7 @@ public interface GitScriptInterface {
     HotfixResult getHotfixProgress(String projectName) throws Exception;
     HotfixResult getLastHotfixStatus(String projectName) throws Exception;
 
+    // Diagnostic (#2): probe getTagGroupsAsync() per provider. Temporary.
+    String diagnoseTagGroups() throws Exception;
+
 }

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/GatewayScriptModule.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/GatewayScriptModule.java
@@ -926,6 +926,11 @@ public class GatewayScriptModule extends AbstractScriptModule implements GitScri
     }
 
     @Override
+    protected String diagnoseTagGroupsImpl() throws Exception {
+        return com.axone_io.ignition.git.managers.GitTagGroupManager.diagnoseTagGroups();
+    }
+
+    @Override
     protected List<String> getGitTrackedProjectNamesImpl() {
         List<String> projectNames = new ArrayList<>();
         try {

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
@@ -95,6 +95,24 @@ public class GitTagGroupManager {
      * content is written when the fetch succeeded (non-{@code null}); otherwise the
      * previously-snapshotted content is restored. Providers with neither are skipped.
      */
+    /**
+     * Returns the subset of {@code byProvider} whose provider names pass
+     * {@link TagExportConfig#isProviderIncluded(String)} — i.e. the same include/System filter the
+     * tag-writing loop applies. Ensures group files are never written for excluded providers.
+     */
+    static Map<String, String> filterIncludedProviders(Map<String, String> byProvider, TagExportConfig config) {
+        Map<String, String> result = new HashMap<>();
+        if (byProvider == null) {
+            return result;
+        }
+        for (Map.Entry<String, String> entry : byProvider.entrySet()) {
+            if (config != null && config.isProviderIncluded(entry.getKey())) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return result;
+    }
+
     static void writeGroupFiles(Path tagsDir, Map<String, String> freshByProvider,
                                 Map<String, String> preservedByProvider) {
         Map<String, String> fresh = freshByProvider == null ? new HashMap<>() : freshByProvider;
@@ -210,8 +228,10 @@ public class GitTagGroupManager {
      *
      * @param tagsDir             the {@code tags/} directory to write into
      * @param preservedByProvider group-file contents snapshotted before the tags dir was cleared
+     * @param config              per-project export config; only its included providers are written,
+     *                            matching the filter used by the tag-writing loop
      */
-    public static void exportTagGroups(Path tagsDir, Map<String, String> preservedByProvider) {
+    public static void exportTagGroups(Path tagsDir, Map<String, String> preservedByProvider, TagExportConfig config) {
         GatewayTagManager gatewayTagManager = context.getTagManager();
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         Map<String, String> freshByProvider = new HashMap<>();
@@ -219,8 +239,10 @@ public class GitTagGroupManager {
         for (TagProvider tagProvider : gatewayTagManager.getTagProviders()) {
             String providerName = tagProvider.getName();
 
-            if (TagExportConfig.SYSTEM_PROVIDER_NAME.equals(providerName)) {
-                logger.debug("Skipping tag group export for built-in System provider.");
+            // Same include/System filter as the tag-writing loop, so excluded providers never get a
+            // .tag-groups.json (which would recreate an empty provider dir).
+            if (config == null || !config.isProviderIncluded(providerName)) {
+                logger.debug("Skipping tag group export for provider '" + providerName + "' (not included / System).");
                 continue;
             }
 
@@ -255,9 +277,9 @@ public class GitTagGroupManager {
             }
         }
 
-        // Never restore a System-provider group file (System is intentionally omitted from tracking).
-        Map<String, String> preserved = new HashMap<>(preservedByProvider == null ? new HashMap<>() : preservedByProvider);
-        preserved.remove(TagExportConfig.SYSTEM_PROVIDER_NAME);
+        // Only restore group files for included providers (this also drops the System provider),
+        // so excluded providers are not resurrected from the snapshot.
+        Map<String, String> preserved = filterIncludedProviders(preservedByProvider, config);
 
         writeGroupFiles(tagsDir, freshByProvider, preserved);
     }

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
@@ -19,7 +19,10 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 import static com.axone_io.ignition.git.GatewayHook.context;
@@ -58,14 +61,94 @@ public class GitTagGroupManager {
 
     static final String TAG_GROUPS_FILENAME = ".tag-groups.json";
 
+    // ========================== NON-DESTRUCTIVE WRITE (fix #1) ==========================
+
+    /**
+     * Reads the existing {@code .tag-groups.json} for every provider under {@code tagsDir}
+     * into an in-memory map keyed by provider name. Must be called <em>before</em> the tags
+     * directory is cleared so a failed fresh fetch can fall back to the prior content.
+     */
+    static Map<String, String> snapshotExistingGroupFiles(Path tagsDir) {
+        Map<String, String> snapshot = new HashMap<>();
+        if (tagsDir == null || !Files.exists(tagsDir)) {
+            return snapshot;
+        }
+        try (DirectoryStream<Path> providerDirs = Files.newDirectoryStream(tagsDir, Files::isDirectory)) {
+            for (Path providerDir : providerDirs) {
+                Path groupsFile = providerDir.resolve(TAG_GROUPS_FILENAME);
+                if (Files.exists(groupsFile)) {
+                    try {
+                        snapshot.put(providerDir.getFileName().toString(), Files.readString(groupsFile));
+                    } catch (IOException e) {
+                        logger.warn("Could not read existing tag groups file for preservation: " + groupsFile, e);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("Could not snapshot existing tag group files under " + tagsDir, e);
+        }
+        return snapshot;
+    }
+
+    /**
+     * Writes group files without ever losing prior data. For each provider, the fresh
+     * content is written when the fetch succeeded (non-{@code null}); otherwise the
+     * previously-snapshotted content is restored. Providers with neither are skipped.
+     */
+    static void writeGroupFiles(Path tagsDir, Map<String, String> freshByProvider,
+                                Map<String, String> preservedByProvider) {
+        Map<String, String> fresh = freshByProvider == null ? new HashMap<>() : freshByProvider;
+        Map<String, String> preserved = preservedByProvider == null ? new HashMap<>() : preservedByProvider;
+
+        TreeSet<String> providers = new TreeSet<>();
+        providers.addAll(fresh.keySet());
+        providers.addAll(preserved.keySet());
+
+        for (String provider : providers) {
+            String content = fresh.get(provider);
+            boolean preservedUsed = false;
+            if (content == null) {
+                // No fresh content (fetch failed/empty) — fall back to the prior file so a
+                // transient failure never deletes committed group definitions.
+                content = preserved.get(provider);
+                preservedUsed = content != null;
+            }
+            if (content == null) {
+                continue;
+            }
+            try {
+                Path providerDir = tagsDir.resolve(provider);
+                Files.createDirectories(providerDir);
+                Files.writeString(providerDir.resolve(TAG_GROUPS_FILENAME), content);
+                if (preservedUsed) {
+                    logger.warn("Preserved existing tag groups for provider '" + provider +
+                            "' because the fresh export produced none (fetch failed or returned empty).");
+                }
+            } catch (IOException e) {
+                logger.warn("Error writing tag groups file for provider '" + provider + "'.", e);
+            }
+        }
+    }
+
     // ========================== EXPORT ==========================
 
     /**
      * Exports tag groups for all tag providers to {@code tags/<provider>/.tag-groups.json}.
      * Called automatically during {@link GitTagManager#exportTag(Path)}.
+     *
+     * <p>Non-destructive: group JSON is built entirely in memory first, then handed to
+     * {@link #writeGroupFiles(Path, Map, Map)}. A provider whose group fetch fails or returns
+     * empty is left out of the fresh map, so its previously-committed group file (from
+     * {@code preservedByProvider}) is restored rather than lost. An empty result is treated as
+     * a failed capture because every provider always has the built-in Default groups.</p>
+     *
+     * @param tagsDir             the {@code tags/} directory to write into
+     * @param preservedByProvider group-file contents snapshotted before the tags dir was cleared
      */
-    public static void exportTagGroups(Path tagsDir) {
+    public static void exportTagGroups(Path tagsDir, Map<String, String> preservedByProvider) {
         GatewayTagManager gatewayTagManager = context.getTagManager();
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Map<String, String> freshByProvider = new HashMap<>();
 
         for (TagProvider tagProvider : gatewayTagManager.getTagProviders()) {
             String providerName = tagProvider.getName();
@@ -75,14 +158,15 @@ public class GitTagGroupManager {
                 continue;
             }
 
-            Path providerDir = tagsDir.resolve(providerName);
-
             try {
                 List<TagGroupConfiguration> tagGroups = tagProvider.getTagGroupsAsync()
                         .get(30, TimeUnit.SECONDS);
 
                 if (tagGroups == null || tagGroups.isEmpty()) {
-                    logger.debug("No tag groups found for provider '" + providerName + "', skipping export.");
+                    // Treat empty as a failed capture and preserve any existing file: every
+                    // provider always has at least the built-in Default/Default Historical groups.
+                    logger.warn("Tag group fetch for provider '" + providerName + "' returned no groups; " +
+                            "preserving any existing group file rather than deleting it.");
                     continue;
                 }
 
@@ -91,23 +175,25 @@ public class GitTagGroupManager {
                         new com.inductiveautomation.ignition.common.gson.JsonArray();
 
                 for (TagGroupConfiguration group : tagGroups) {
-                    JsonObject groupJson = serializeTagGroup(group);
-                    groupsArray.add(groupJson);
+                    groupsArray.add(serializeTagGroup(group));
                 }
 
                 root.add("tagGroups", groupsArray);
+                freshByProvider.put(providerName, gson.toJson(root));
 
-                Files.createDirectories(providerDir);
-                Path groupsFile = providerDir.resolve(TAG_GROUPS_FILENAME);
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                Files.writeString(groupsFile, gson.toJson(root));
-
-                logger.info("Exported " + tagGroups.size() + " tag group(s) for provider '" + providerName + "'.");
+                logger.info("Captured " + tagGroups.size() + " tag group(s) for provider '" + providerName + "'.");
 
             } catch (Exception e) {
-                logger.warn("Error exporting tag groups for provider '" + providerName + "'.", e);
+                logger.warn("Error exporting tag groups for provider '" + providerName +
+                        "'; preserving any existing group file rather than deleting it.", e);
             }
         }
+
+        // Never restore a System-provider group file (System is intentionally omitted from tracking).
+        Map<String, String> preserved = new HashMap<>(preservedByProvider == null ? new HashMap<>() : preservedByProvider);
+        preserved.remove(TagExportConfig.SYSTEM_PROVIDER_NAME);
+
+        writeGroupFiles(tagsDir, freshByProvider, preserved);
     }
 
     /**

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagGroupManager.java
@@ -130,6 +130,72 @@ public class GitTagGroupManager {
         }
     }
 
+    // ========================== DIAGNOSTIC (#2) ==========================
+
+    /**
+     * Diagnostic probe for the "empty tag groups on export" issue (#2). For every tag provider
+     * it calls {@code getTagGroupsAsync()} exactly the way {@link #exportTagGroups} does and
+     * reports, per provider: elapsed time, group count, the group names, or the exception/timeout.
+     *
+     * <p>Runnable live from the Designer/Gateway script console:
+     * {@code print system.git.diagnoseTagGroups()}. The full report is also written to the
+     * gateway log at INFO. This is a temporary diagnostic — remove once #2 is resolved.</p>
+     *
+     * @return a human-readable multi-line report
+     */
+    public static String diagnoseTagGroups() {
+        GatewayTagManager gatewayTagManager = context.getTagManager();
+        StringBuilder sb = new StringBuilder();
+        sb.append("=== Tag Group Diagnostic ===\n");
+
+        List<TagProvider> providers = gatewayTagManager.getTagProviders();
+        sb.append("Providers found: ").append(providers.size()).append("\n");
+
+        for (TagProvider tagProvider : providers) {
+            String providerName = tagProvider.getName();
+            sb.append("\nProvider '").append(providerName).append("'");
+            if (TagExportConfig.SYSTEM_PROVIDER_NAME.equals(providerName)) {
+                sb.append(" [System — skipped by export]");
+            }
+            sb.append(":\n");
+
+            long start = System.currentTimeMillis();
+            try {
+                List<TagGroupConfiguration> groups = tagProvider.getTagGroupsAsync()
+                        .get(30, TimeUnit.SECONDS);
+                long ms = System.currentTimeMillis() - start;
+
+                if (groups == null) {
+                    sb.append("  -> NULL result after ").append(ms).append("ms\n");
+                } else if (groups.isEmpty()) {
+                    sb.append("  -> EMPTY list after ").append(ms).append("ms " +
+                            "(unexpected: built-in Default groups should always be present)\n");
+                } else {
+                    List<String> names = new ArrayList<>();
+                    for (TagGroupConfiguration g : groups) {
+                        names.add(g.getName());
+                    }
+                    sb.append("  -> ").append(groups.size()).append(" group(s) in ")
+                            .append(ms).append("ms: ").append(names).append("\n");
+                }
+            } catch (Exception e) {
+                long ms = System.currentTimeMillis() - start;
+                sb.append("  -> ").append(e.getClass().getSimpleName())
+                        .append(" after ").append(ms).append("ms: ").append(e.getMessage());
+                Throwable cause = e.getCause();
+                if (cause != null) {
+                    sb.append(" | cause: ").append(cause.getClass().getSimpleName())
+                            .append(": ").append(cause.getMessage());
+                }
+                sb.append("\n");
+            }
+        }
+
+        String report = sb.toString();
+        logger.info(report);
+        return report;
+    }
+
     // ========================== EXPORT ==========================
 
     /**

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
@@ -10,6 +10,7 @@ import com.inductiveautomation.ignition.common.gson.JsonObject;
 import com.inductiveautomation.ignition.common.tags.TagUtilities;
 import com.inductiveautomation.ignition.common.tags.config.CollisionPolicy;
 import com.inductiveautomation.ignition.common.tags.config.TagConfigurationModel;
+import com.inductiveautomation.ignition.common.tags.config.TagGroupConfiguration;
 import com.inductiveautomation.ignition.common.tags.model.TagPath;
 import com.inductiveautomation.ignition.common.tags.model.TagProvider;
 import com.inductiveautomation.ignition.common.tags.paths.BasicTagPath;
@@ -132,6 +133,84 @@ public class GitTagManager {
         return sb.toString();
     }
 
+    // ========================== TAG GROUP RECONCILIATION (fix #3) ==========================
+
+    /**
+     * Walks a tag JSON node and remaps any {@code tagGroup} reference that is not present in
+     * {@code knownGroups} to {@code fallbackGroup}, so a tag whose group could not be restored
+     * imports cleanly instead of erroring. Empty/absent {@code tagGroup} values (which already
+     * mean "use the provider default") are left untouched.
+     *
+     * @return the number of tag nodes that were remapped
+     */
+    static int reconcileUnknownTagGroups(JsonObject node, Set<String> knownGroups, String fallbackGroup) {
+        if (node == null) {
+            return 0;
+        }
+        int count = 0;
+
+        if (node.has("tagGroup") && node.get("tagGroup").isJsonPrimitive()) {
+            String group = node.get("tagGroup").getAsString();
+            // An empty tagGroup already means "use the provider default", so leave it alone.
+            if (group != null && !group.isEmpty()
+                    && !group.equals(fallbackGroup)
+                    && !knownGroups.contains(group)) {
+                node.addProperty("tagGroup", fallbackGroup);
+                count++;
+            }
+        }
+
+        // Recurse into child tags, which may be an array (import shape) or an object (keyed by name).
+        if (node.has("tags")) {
+            JsonElement tagsEl = node.get("tags");
+            if (tagsEl.isJsonArray()) {
+                for (JsonElement child : tagsEl.getAsJsonArray()) {
+                    if (child.isJsonObject()) {
+                        count += reconcileUnknownTagGroups(child.getAsJsonObject(), knownGroups, fallbackGroup);
+                    }
+                }
+            } else if (tagsEl.isJsonObject()) {
+                for (Map.Entry<String, JsonElement> e : tagsEl.getAsJsonObject().entrySet()) {
+                    if (e.getValue().isJsonObject()) {
+                        count += reconcileUnknownTagGroups(e.getValue().getAsJsonObject(), knownGroups, fallbackGroup);
+                    }
+                }
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * Fetches the tag group names currently defined on {@code tagProvider} and remaps any
+     * unresolved {@code tagGroup} reference in {@code root} to {@code Default}, so tags whose
+     * group could not be restored import cleanly instead of erroring. If the provider's group
+     * list can't be determined, reconciliation is skipped (tags import as-is).
+     */
+    private static void reconcileWithProviderGroups(TagProvider tagProvider, String providerName, JsonObject root) {
+        try {
+            List<TagGroupConfiguration> groups = tagProvider.getTagGroupsAsync().get(10, TimeUnit.SECONDS);
+            if (groups == null || groups.isEmpty()) {
+                logger.warn("Could not determine tag groups for provider '" + providerName +
+                        "'; importing tags without group reconciliation.");
+                return;
+            }
+            Set<String> known = new HashSet<>();
+            for (TagGroupConfiguration g : groups) {
+                known.add(g.getName());
+            }
+            int remapped = reconcileUnknownTagGroups(root, known, "Default");
+            if (remapped > 0) {
+                logger.warn("Remapped " + remapped + " tag(s) in provider '" + providerName +
+                        "' to the 'Default' tag group because their configured tag group is not present " +
+                        "on this gateway. Restore the missing tag group(s) and re-import to keep the original rates.");
+            }
+        } catch (Exception e) {
+            logger.warn("Could not reconcile tag groups for provider '" + providerName +
+                    "'; importing tags as-is.", e);
+        }
+    }
+
     // ========================== IMPORT ==========================
 
     /**
@@ -187,6 +266,10 @@ public class GitTagManager {
             if (tagProvider != null) {
                 try {
                     String json = FileUtils.readFileToString(file, StandardCharsets.UTF_8.toString());
+                    // Reconcile unresolved tag groups before import (fix #3).
+                    JsonObject root = TAG_GSON.fromJson(json, JsonObject.class);
+                    reconcileWithProviderGroups(tagProvider, providerName, root);
+                    json = TAG_GSON.toJson(root);
                     tagProvider.importTagsAsync(new BasicTagPath(""), json, "JSON", collisionPolicy, null)
                         .get(30, TimeUnit.SECONDS);
                     logger.info("Imported tags for provider '" + providerName + "' (legacy format).");
@@ -248,6 +331,10 @@ public class GitTagManager {
 
                     JsonObject root = new JsonObject();
                     root.add("tags", tagsArray);
+
+                    // Remap any tag referencing a group that isn't present on this gateway so the
+                    // import doesn't error the tag (fix #3).
+                    reconcileWithProviderGroups(tagProvider, providerName, root);
 
                     String jsonStr = TAG_GSON.toJson(root);
                     var tagResult = tagProvider.importTagsAsync(new BasicTagPath(""), jsonStr, "JSON", collisionPolicy, null)
@@ -376,6 +463,9 @@ public class GitTagManager {
                 JsonObject root = new JsonObject();
                 root.add("tags", typesArray);
 
+                // UDT member tags can also reference custom groups — reconcile before import (fix #3).
+                reconcileWithProviderGroups(tagProvider, tagProvider.getName(), root);
+
                 String jsonStr = TAG_GSON.toJson(root);
                 logger.info("Importing UDT type '" + name + "' with pathPrefix='" + pathPrefix + "', JSON length=" + jsonStr.length());
                 logger.debug("UDT import JSON: " + jsonStr);
@@ -491,6 +581,10 @@ public class GitTagManager {
         // Load config BEFORE clearing the directory so user settings are preserved
         TagExportConfig config = loadTagExportConfig(tagFolderPath);
 
+        // Snapshot existing group files BEFORE clearing so a failed group fetch below can fall
+        // back to the prior content instead of leaving the tags directory with no group files.
+        Map<String, String> preservedGroups = GitTagGroupManager.snapshotExistingGroupFiles(tagFolderPath);
+
         clearDirectory(tagFolderPath);
 
         try {
@@ -533,8 +627,9 @@ public class GitTagManager {
             // Write the config file (preserves user settings for next import)
             writeTagExportConfig(tagFolderPath, config);
 
-            // Export tag groups (scan classes) for all providers
-            GitTagGroupManager.exportTagGroups(tagFolderPath);
+            // Export tag groups (scan classes) for all providers. Passing the pre-clear snapshot
+            // makes this non-destructive: providers whose groups can't be fetched keep their prior file.
+            GitTagGroupManager.exportTagGroups(tagFolderPath, preservedGroups);
 
         } catch (Exception e) {
             logger.error("Error exporting tags: " + e.toString(), e);

--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitTagManager.java
@@ -627,9 +627,10 @@ public class GitTagManager {
             // Write the config file (preserves user settings for next import)
             writeTagExportConfig(tagFolderPath, config);
 
-            // Export tag groups (scan classes) for all providers. Passing the pre-clear snapshot
-            // makes this non-destructive: providers whose groups can't be fetched keep their prior file.
-            GitTagGroupManager.exportTagGroups(tagFolderPath, preservedGroups);
+            // Export tag groups (scan classes) for the same included providers as the tag files.
+            // Passing the pre-clear snapshot makes this non-destructive: providers whose groups can't
+            // be fetched keep their prior file.
+            GitTagGroupManager.exportTagGroups(tagFolderPath, preservedGroups, config);
 
         } catch (Exception e) {
             logger.error("Error exporting tags: " + e.toString(), e);

--- a/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagGroupManagerTest.java
+++ b/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagGroupManagerTest.java
@@ -91,6 +91,41 @@ public class GitTagGroupManagerTest {
         assertFalse(Files.exists(tagsDir.resolve("Ghost")));
     }
 
+    @Test
+    public void filterIncludedProviders_dropsExcludedAndSystemProviders() {
+        // includedProviders = [WHK01] -> only WHK01 kept; default excluded by config, System always excluded.
+        com.axone_io.ignition.git.TagExportConfig config = new com.axone_io.ignition.git.TagExportConfig(
+                java.util.List.of("WHK01"), new java.util.ArrayList<>(), "o");
+        Map<String, String> in = new HashMap<>();
+        in.put("WHK01", WHK01_JSON);
+        in.put("default", DEFAULT_JSON);
+        in.put("System", DEFAULT_JSON);
+
+        Map<String, String> out = GitTagGroupManager.filterIncludedProviders(in, config);
+
+        assertEquals(1, out.size());
+        assertEquals(WHK01_JSON, out.get("WHK01"));
+        assertFalse(out.containsKey("default"));
+        assertFalse(out.containsKey("System"));
+    }
+
+    @Test
+    public void filterIncludedProviders_emptyIncludeListKeepsAllButSystem() {
+        // Empty includedProviders means "all providers", but System is always excluded.
+        com.axone_io.ignition.git.TagExportConfig config = new com.axone_io.ignition.git.TagExportConfig();
+        Map<String, String> in = new HashMap<>();
+        in.put("WHK01", WHK01_JSON);
+        in.put("default", DEFAULT_JSON);
+        in.put("System", DEFAULT_JSON);
+
+        Map<String, String> out = GitTagGroupManager.filterIncludedProviders(in, config);
+
+        assertEquals(2, out.size());
+        assertTrue(out.containsKey("WHK01"));
+        assertTrue(out.containsKey("default"));
+        assertFalse(out.containsKey("System"));
+    }
+
     private void writeGroupFile(Path tagsDir, String provider, String content) throws Exception {
         Path dir = tagsDir.resolve(provider);
         Files.createDirectories(dir);

--- a/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagGroupManagerTest.java
+++ b/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagGroupManagerTest.java
@@ -1,0 +1,99 @@
+package com.axone_io.ignition.git.managers;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the non-destructive tag-group export behaviour (fix #1).
+ *
+ * <p>Regression context: on the production (8.3) gateway, {@code exportTag} cleared the
+ * tags directory and then failed to fetch tag groups, leaving every provider's
+ * {@code .tag-groups.json} deleted. These tests pin the guarantee that a failed/empty
+ * fetch preserves the previously-committed group file instead of losing it.</p>
+ */
+public class GitTagGroupManagerTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private static final String WHK01_JSON =
+            "{\n  \"tagGroups\": [\n    { \"name\": \"Fast\", \"rate\": 250 },\n" +
+            "    { \"name\": \"Modbus\", \"rate\": 1000 }\n  ]\n}";
+    private static final String DEFAULT_JSON =
+            "{\n  \"tagGroups\": [\n    { \"name\": \"Default\", \"rate\": 1000 }\n  ]\n}";
+
+    @Test
+    public void snapshotExistingGroupFiles_readsGroupFilePerProvider() throws Exception {
+        Path tagsDir = tempFolder.newFolder("tags").toPath();
+        writeGroupFile(tagsDir, "WHK01", WHK01_JSON);
+        writeGroupFile(tagsDir, "default", DEFAULT_JSON);
+        // A provider directory with tags but no group file must not appear in the snapshot.
+        Files.createDirectories(tagsDir.resolve("Spark"));
+
+        Map<String, String> snapshot = GitTagGroupManager.snapshotExistingGroupFiles(tagsDir);
+
+        assertEquals(2, snapshot.size());
+        assertEquals(WHK01_JSON, snapshot.get("WHK01"));
+        assertEquals(DEFAULT_JSON, snapshot.get("default"));
+        assertFalse("provider without a group file must be absent", snapshot.containsKey("Spark"));
+    }
+
+    @Test
+    public void writeGroupFiles_preservesExistingWhenFreshFetchFailed() throws Exception {
+        // Simulates the post-clearDirectory state: the tags dir is empty and the fresh
+        // fetch for WHK01 came back null (timeout/exception/empty on the source gateway).
+        Path tagsDir = tempFolder.newFolder("tags").toPath();
+        Map<String, String> preserved = new HashMap<>();
+        preserved.put("WHK01", WHK01_JSON);
+        Map<String, String> fresh = new HashMap<>();
+        fresh.put("WHK01", null); // fetch failed
+
+        GitTagGroupManager.writeGroupFiles(tagsDir, fresh, preserved);
+
+        Path file = tagsDir.resolve("WHK01").resolve(GitTagGroupManager.TAG_GROUPS_FILENAME);
+        assertTrue("failed fetch must not delete the prior group file", Files.exists(file));
+        assertEquals(WHK01_JSON, Files.readString(file));
+    }
+
+    @Test
+    public void writeGroupFiles_writesFreshContentWhenFetchSucceeded() throws Exception {
+        Path tagsDir = tempFolder.newFolder("tags").toPath();
+        Map<String, String> preserved = new HashMap<>();
+        preserved.put("WHK01", DEFAULT_JSON); // stale prior content
+        Map<String, String> fresh = new HashMap<>();
+        fresh.put("WHK01", WHK01_JSON); // successful fetch
+
+        GitTagGroupManager.writeGroupFiles(tagsDir, fresh, preserved);
+
+        Path file = tagsDir.resolve("WHK01").resolve(GitTagGroupManager.TAG_GROUPS_FILENAME);
+        assertEquals("fresh content must overwrite preserved", WHK01_JSON, Files.readString(file));
+    }
+
+    @Test
+    public void writeGroupFiles_skipsProviderWithNeitherFreshNorPreserved() throws Exception {
+        Path tagsDir = tempFolder.newFolder("tags").toPath();
+        Map<String, String> fresh = new HashMap<>();
+        fresh.put("Ghost", null);
+        Map<String, String> preserved = new HashMap<>();
+
+        GitTagGroupManager.writeGroupFiles(tagsDir, fresh, preserved);
+
+        assertFalse(Files.exists(tagsDir.resolve("Ghost")));
+    }
+
+    private void writeGroupFile(Path tagsDir, String provider, String content) throws Exception {
+        Path dir = tagsDir.resolve(provider);
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve(GitTagGroupManager.TAG_GROUPS_FILENAME), content);
+    }
+}

--- a/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagManagerTest.java
+++ b/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitTagManagerTest.java
@@ -1,5 +1,6 @@
 package com.axone_io.ignition.git.managers;
 
+import com.inductiveautomation.ignition.common.gson.Gson;
 import com.inductiveautomation.ignition.common.gson.JsonObject;
 import org.junit.Rule;
 import org.junit.Test;
@@ -8,12 +9,81 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.nio.file.Files;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class GitTagManagerTest {
+
+    private static final Gson GSON = new Gson();
+
+    private static Set<String> known(String... names) {
+        return new HashSet<>(java.util.Arrays.asList(names));
+    }
+
+    private static JsonObject parse(String json) {
+        return GSON.fromJson(json, JsonObject.class);
+    }
+
+    // ========================== reconcileUnknownTagGroups (fix #3) ==========================
+
+    @Test
+    public void reconcile_remapsUnknownGroupToFallback() {
+        JsonObject tag = parse("{\"name\":\"Level\",\"tagType\":\"AtomicTag\"," +
+                "\"tagGroup\":\"FactoryPacks Leased\"}");
+
+        int remapped = GitTagManager.reconcileUnknownTagGroups(
+                tag, known("Default", "Default Historical"), "Default");
+
+        assertEquals(1, remapped);
+        assertEquals("Default", tag.get("tagGroup").getAsString());
+    }
+
+    @Test
+    public void reconcile_leavesKnownGroupUntouched() {
+        JsonObject tag = parse("{\"name\":\"Level\",\"tagGroup\":\"Fast\"}");
+
+        int remapped = GitTagManager.reconcileUnknownTagGroups(
+                tag, known("Default", "Fast"), "Default");
+
+        assertEquals(0, remapped);
+        assertEquals("Fast", tag.get("tagGroup").getAsString());
+    }
+
+    @Test
+    public void reconcile_recursesIntoNestedFoldersAndTags() {
+        JsonObject root = parse("{\"tags\":[" +
+                "{\"name\":\"Folder\",\"tagType\":\"Folder\",\"tags\":[" +
+                "  {\"name\":\"A\",\"tagGroup\":\"Recipe\"}," +
+                "  {\"name\":\"B\",\"tagGroup\":\"Default\"}" +
+                "]}," +
+                "{\"name\":\"C\",\"tagGroup\":\"Location\"}" +
+                "]}");
+
+        int remapped = GitTagManager.reconcileUnknownTagGroups(
+                root, known("Default"), "Default");
+
+        assertEquals(2, remapped);
+    }
+
+    @Test
+    public void reconcile_ignoresEmptyAndMissingTagGroup() {
+        // Empty tagGroup already means "use default" in Ignition; a node without the
+        // property is a folder/container. Neither should be remapped or counted.
+        JsonObject root = parse("{\"tags\":[" +
+                "{\"name\":\"A\",\"tagGroup\":\"\"}," +
+                "{\"name\":\"Folder\",\"tagType\":\"Folder\"}" +
+                "]}");
+
+        int remapped = GitTagManager.reconcileUnknownTagGroups(
+                root, known("Default"), "Default");
+
+        assertEquals(0, remapped);
+    }
 
     @Test
     public void encodeFsName_leavesSafeNamesUnchanged() {


### PR DESCRIPTION
## Problem

Tags belonging to a **custom tag group** (not the built-in `Default`/`Default Historical`) errored on pull; newly-created tags worked. Root cause: `GitTagManager.exportTag()` ran `clearDirectory(tags/)` and then wrote each provider's `.tag-groups.json` **only if** `getTagGroupsAsync()` returned a non-empty list. When a provider wasn't in `getTagManager().getTagProviders()` at export time — or the fetch was empty/failed — the wipe destroyed the committed group file with no replacement. A production "catch up" export deleted **all 9** `.tag-groups.json` files this way, so pulls could no longer restore groups and tags referencing them errored.

## Fixes

**#1 — Non-destructive export** (`GitTagGroupManager`)
- Snapshot existing `.tag-groups.json` **before** the directory is cleared.
- Build group JSON in memory; a failed/empty fetch is treated as failure (every provider always has the built-in Default groups) and **preserves** the prior file instead of deleting it.
- The System provider is never restored (stays omitted from tracking).

**#3 — Import reconciliation** (`GitTagManager`)
- `reconcileUnknownTagGroups()` remaps a tag's unresolved `tagGroup` to `Default` instead of erroring the tag, across individual-file, UDT, and legacy import paths. Logs how many tags were remapped (their intended scan rate is lost until the group is restored — a safety net, not a substitute for restoring groups).

**Diagnostic** — `diagnoseTagGroups()` RPC reports, per provider, what `getTagGroupsAsync()` returns (count / names / exception / timing).

## Testing

- 8 new unit tests (pure logic); full gateway suite **83/83 green**.
- **Live-tested on an Ignition 8.3.3 gateway:**
  - `getTagGroupsAsync()` works correctly (WHK01 → 8 custom groups, ~1ms) — no 8.3 API defect.
  - `getTagProviders()` is populated **progressively at startup** (4 → 6 providers) — the real trigger for the loss.
  - A real export logged `Captured 8 tag group(s) for 'WHK01'` and `Preserved existing tag groups for 'default'/'Spark'/'QSI_UDTs'/'NextTrend-NextTrend'` (providers absent from the gateway) — **files preserved, not deleted**, confirming the fix.

## Follow-ups (not in this PR)

- Production repo still has **no** group files — needs one clean re-export from a fully-started production gateway with this module, then commit.
- `diagnoseTagGroups()` is reachable once it's added to the curated `GitScriptFunctions` scripting surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new tag-group diagnostic action to help identify provider issues and group availability.
* **Bug Fixes**
  * Tag imports now reconcile unknown or missing tag-group references by safely remapping to a fallback group.
  * Tag group exports are now non-destructive: previously saved group files are preserved and restored when fresh provider data is unavailable.
* **Tests**
  * Expanded automated coverage for tag import reconciliation and non-destructive tag-group export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->