### PR TITLE
fix(import): don't emit folder resources for paths that have their own resource.json

### DIFF
--- a/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitProjectManager.java
+++ b/git-gateway/src/main/java/com/axone_io/ignition/git/managers/GitProjectManager.java
@@ -87,6 +87,19 @@ public class GitProjectManager {
         Set<StringPath> createdFolders = new HashSet<>();
 
         Set<Map.Entry<String, byte[]>> files = listFiles(projectPath);
+
+        // Pre-seed with every directory that has its own resource.json so
+        // createParentFolderResources never emits a folder resource for a path
+        // that is itself a real resource. Without this, a nested resource
+        // (e.g. a Perspective view inside another view's folder) produces both
+        // a folder and a data resource at the parent path, and a cold
+        // createOrReplace fails with "resource already exists".
+        Set<StringPath> resourceJsonDirs = files.stream()
+                .filter(e -> e.getKey().endsWith("/resource.json"))
+                .map(e -> StringPath.parse(StringUtils.substringBeforeLast(e.getKey(), "/")))
+                .collect(Collectors.toSet());
+        createdFolders.addAll(resourceJsonDirs);
+
         files.stream().collect(Collectors.groupingBy(e -> StringUtils.substringBeforeLast(e.getKey(), "/")))
                 .forEach((resourcePath, listOfFileNodes) -> {
                     StringPath stringPath = StringPath.parse(resourcePath);
@@ -100,7 +113,10 @@ public class GitProjectManager {
                         Map<String, byte[]> dataMap = createDataMap(resourceManifest, listOfFileNodes);
 
                         resources.add(createResourceBuilder(projectName, stringPath, resourceManifest, dataMap).build());
-                    } else if (!createdFolders.contains(stringPath)) {
+                    } else if (!createdFolders.contains(stringPath) || resourceJsonDirs.contains(stringPath)) {
+                        // Second clause: a resource.json existed here but failed to
+                        // parse (manifest == null) — fall back to a plain folder so
+                        // any children keep a valid parent, as before the pre-seed.
                         resources.add(createResourceBuilder(projectName, stringPath, ResourceManifest.newBuilder().build(), new HashMap<>()).setFolder(true).build());
                         createdFolders.add(stringPath);
                     }

--- a/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitProjectManagerTest.java
+++ b/git-gateway/src/test/java/com/axone_io/ignition/git/managers/GitProjectManagerTest.java
@@ -1,0 +1,100 @@
+package com.axone_io.ignition.git.managers;
+
+import com.inductiveautomation.ignition.common.resourcecollection.Resource;
+import com.inductiveautomation.ignition.common.resourcecollection.ResourcePath;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GitProjectManagerTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private static final String RESOURCE_JSON =
+            "{\"scope\":\"G\",\"version\":1,\"restricted\":false,\"overridable\":true," +
+            "\"files\":[\"view.json\"],\"attributes\":{}}";
+
+    private void writeView(Path dir) throws Exception {
+        Files.createDirectories(dir);
+        Files.write(dir.resolve("view.json"), "{}".getBytes());
+        Files.write(dir.resolve("resource.json"), RESOURCE_JSON.getBytes());
+    }
+
+    /**
+     * A view nested inside another view's folder must not produce both a
+     * folder resource and a data resource at the parent path — that made a
+     * cold createOrReplace fail with "resource already exists"
+     * (views/Changeover/Popups/EquipmentAction in WHK-Global).
+     */
+    @Test
+    public void nestedViewDoesNotDuplicateParentResource() throws Exception {
+        File root = tmp.newFolder("project");
+        Path views = root.toPath().resolve("com.inductiveautomation.perspective/views/Popups");
+
+        writeView(views.resolve("EquipmentAction"));
+        writeView(views.resolve("EquipmentAction/ActionButton"));
+
+        Set<Resource> resources = GitProjectManager.importFromFolder(root.toPath(), "TestProject");
+
+        Map<ResourcePath, Integer> counts = new HashMap<>();
+        for (Resource r : resources) {
+            counts.merge(r.getResourcePath(), 1, Integer::sum);
+        }
+        for (Map.Entry<ResourcePath, Integer> e : counts.entrySet()) {
+            assertEquals("duplicate resource emitted for " + e.getKey(), 1, (int) e.getValue());
+        }
+
+        Resource parent = find(resources, "Popups/EquipmentAction");
+        Resource child = find(resources, "Popups/EquipmentAction/ActionButton");
+        assertFalse("parent with its own resource.json must be a data resource, not a folder",
+                parent.isFolder());
+        assertFalse(child.isFolder());
+        assertTrue("plain parent folders still created",
+                find(resources, "Popups").isFolder());
+    }
+
+    /**
+     * A directory whose resource.json is malformed keeps the pre-fix fallback:
+     * it becomes a plain folder (exactly once) so children keep a valid parent.
+     */
+    @Test
+    public void malformedResourceJsonStillCreatesFolder() throws Exception {
+        File root = tmp.newFolder("project");
+        Path bad = root.toPath().resolve("com.inductiveautomation.perspective/views/Broken");
+        Files.createDirectories(bad);
+        Files.write(bad.resolve("resource.json"), "{not-json".getBytes());
+        writeView(bad.resolve("Child"));
+
+        Set<Resource> resources = GitProjectManager.importFromFolder(root.toPath(), "TestProject");
+
+        Set<ResourcePath> seen = new HashSet<>();
+        for (Resource r : resources) {
+            assertTrue("duplicate resource emitted for " + r.getResourcePath(),
+                    seen.add(r.getResourcePath()));
+        }
+        assertTrue(find(resources, "Broken").isFolder());
+        assertFalse(find(resources, "Broken/Child").isFolder());
+    }
+
+    private static Resource find(Set<Resource> resources, String pathSuffix) {
+        for (Resource r : resources) {
+            if (String.valueOf(r.getResourcePath()).endsWith(pathSuffix)) {
+                return r;
+            }
+        }
+        throw new AssertionError("no resource ending in " + pathSuffix + " found in " + resources);
+    }
+}


### PR DESCRIPTION
importFromFolder() crashed a cold createOrReplace with
'IllegalStateException: resource already exists' whenever a resource was
nested inside another resource's folder (e.g. a Perspective view inside a
view folder — WHK-Global's views/Changeover/Popups/EquipmentAction):
createParentFolderResources() emitted a folder resource for the parent
path, then the main loop added the same path as a data resource.

Pre-seed createdFolders with every directory containing a resource.json so
parent-folder synthesis skips real resources. Directories whose
resource.json fails to parse keep the previous fallback (plain folder) so
their children retain a valid parent.

Only fresh gateways ever hit this (commissioning import into a new
project); existing projects tolerate the duplicate, which is why dev
gateways never crashed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved importing of nested resources to prevent duplicate parent folders.
  * Preserved parent folders when resource metadata is malformed, allowing nested resources to import correctly.

* **Tests**
  * Added coverage for nested resource imports and malformed resource metadata scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->